### PR TITLE
fix: pool DB connections to prevent Supabase client exhaustion

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -100,4 +100,12 @@ def get_engine(database_url: str | None = None) -> Engine:
     if not db_url:
         raise RuntimeError("DATABASE_URL is not set")
 
-    return create_engine(db_url, future=True)
+    # Pool connections to avoid exhausting max_clients on frequent requests
+    return create_engine(
+        db_url,
+        future=True,
+        pool_size=5,
+        max_overflow=5,
+        pool_pre_ping=True,
+        pool_recycle=300,
+    )


### PR DESCRIPTION
## What this does

Adds connection pooling to the SQLAlchemy engine so the backend reuses a small set of warm database connections instead of opening a fresh one for every single request.

## Why

Without pooling, hammering the map (pan + /locations + /image-pairs fires many requests per second) would exhaust the Supabase free-tier connection cap and the backend would start returning `OperationalError: too many clients`. Five workers + five overflow + pre-ping + 5-minute recycle keeps usage safely under the shared cap while surviving Supabase's idle drops.

## Plain-English settings

- `pool_size=5` — keep 5 warm connections ready to reuse
- `max_overflow=5` — allow up to 5 extra short-lived connections during spikes
- `pool_pre_ping=True` — test a connection with `SELECT 1` before using it, in case Supabase dropped it while idle
- `pool_recycle=300` — throw away any connection older than 5 minutes to avoid stale TCP state

## How to verify
Pan the map hard for 30 seconds. Backend logs stay clean; no `too many clients` errors.

Closes #60