### PR TITLE
chore: add one-command local backend setup (#59)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,24 @@
+# --- Database ---
+# Default value targets the Compose service. For manual / non-Docker runs, use localhost:5433.
+DATABASE_URL=postgresql+psycopg://utd:utdpass@db:5432/utd_data
+# For production Supabase, replace with the pooled connection string
+
+# --- Gemini ---
+GEMINI_API_KEY=
+
+# --- Local preprocessing ---
+PARSED_DATA_DIR=data-example
+# Optional: override the VLM dataset directory (defaults to PARSED_DATA_DIR).
+VLM_DATASET_DIR=
+
+# --- Supabase image storage ---
+SUPABASE_URL=
+SUPABASE_IMAGES_BUCKET=images
+SUPABASE_STRIP_PREFIX=images/
+SUPABASE_USE_BASENAME=false
+SUPABASE_SERVICE_ROLE_KEY=
+
+# --- CORS ---
+CORS_ALLOW_ORIGIN_REGEX=^https://.*\.vercel\.app$
+# Optional: comma-separated list of explicit origins. Takes precedence over the regex.
+CORS_ALLOW_ORIGINS=

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ log.txt
 # Environment variables
 .env
 .env.*
+!.env.example
 service_role.txt
 
 # VLM pipeline local artifacts

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+
+RUN pip install --no-cache-dir uv
+
+WORKDIR /app
+
+COPY requirements.txt requirements-dev.txt ./
+RUN uv pip install --system -r requirements-dev.txt
+
+RUN useradd --create-home --uid 1000 appuser \
+    && chown -R appuser:appuser /app
+USER appuser
+
+EXPOSE 8000
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+# Backend dev commands. Run `make dev` after copying .env.example to .env.
+
+.PHONY: dev db seed test eval lint
+
+.env:
+	cp .env.example .env
+	@echo ">>> Created .env from .env.example. Fill in GEMINI_API_KEY and rerun 'make dev'."
+	@false
+
+dev: .env
+	docker compose up --build
+
+db:
+	docker compose up -d db
+
+seed:
+	python util/seed_minimal.py
+
+test:
+	pytest
+
+eval:
+	python util/vlm_eval.py --disaster-id hurricane-florence
+
+lint:
+	ruff check . && black --check .

--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+ENV_VARS = (
+    "DATABASE_URL",
+    "GEMINI_API_KEY",
+    "PARSED_DATA_DIR",
+    "SUPABASE_URL",
+    "SUPABASE_IMAGES_BUCKET",
+    "SUPABASE_STRIP_PREFIX",
+    "SUPABASE_USE_BASENAME",
+    "SUPABASE_SERVICE_ROLE_KEY",
+    "CORS_ALLOW_ORIGIN_REGEX",
+    "CORS_ALLOW_ORIGINS",
+)
+
+REQUIRED = ("DATABASE_URL", "GEMINI_API_KEY")
+
+
+def validate_env() -> None:
+    for name in ENV_VARS:
+        if not os.getenv(name):
+            logger.warning("env var %s is not set", name)
+
+    missing_required = [name for name in REQUIRED if not os.getenv(name)]
+    if missing_required:
+        raise RuntimeError(
+            f"missing required env vars: {', '.join(missing_required)}"
+        )

--- a/app/main.py
+++ b/app/main.py
@@ -10,8 +10,11 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from sqlalchemy import text
 
-from app.db import get_engine  # ← db first
-from app.routers.chat import router as chat_router  # ← chat after
+from app.config import validate_env
+from app.db import get_engine
+from app.routers.chat import router as chat_router
+
+validate_env()
 
 
 def _parse_cors_origins() -> list[str]:
@@ -36,7 +39,7 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
-app.include_router(chat_router)  # ← after app is created
+app.include_router(chat_router)
 PARSED_DATA_DIR = (
     Path(os.getenv("PARSED_DATA_DIR", "data-example")).expanduser().resolve()
 )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+services:
+  db:
+    image: postgis/postgis:16-3.4
+    environment:
+      POSTGRES_USER: utd
+      POSTGRES_PASSWORD: utdpass
+      POSTGRES_DB: utd_data
+    ports:
+      - "5433:5432"
+    volumes:
+      - utd-pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U utd"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  api:
+    build: .
+    env_file: .env
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./:/app
+    depends_on:
+      db:
+        condition: service_healthy
+
+volumes:
+  utd-pgdata:

--- a/docs/manual-setup.md
+++ b/docs/manual-setup.md
@@ -1,0 +1,68 @@
+This is the manual setup path for contributors who cannot use Docker Compose. Prefer the Quick Start in the main README.
+
+# Backend
+
+## Setup
+
+Recommended to use [uv](https://docs.astral.sh/uv/getting-started/installation/) to manage virtual environment and pip packages.
+
+### First Installation
+
+Create virtual environment:
+
+```bash
+uv venv
+```
+
+Install dependencies:
+
+```bash
+uv pip install -r requirements.txt
+```
+
+## PostgreSQL + PostGIS
+
+Note: The following names and passwords are only for development purposes, and will be different in production.
+
+Create a PostgreSQL database with PostGIS enabled, then set:
+
+```bash
+docker run --name utd-postgis \
+    -e POSTGRES_USER=utd \
+    -e POSTGRES_PASSWORD=utdpass \
+    -e POSTGRES_DB=utd_data \
+    -p 5433:5432 \
+    -d postgis/postgis:16-3.4
+```
+
+If this not the first time running, use now:
+
+```bash
+docker start utd-postgis
+```
+
+Make sure your environment has the variable DATABASE_URL which corresponds to the new DB.
+
+```bash
+export DATABASE_URL='postgresql+psycopg://utd:utdpass@localhost:5433/utd_data'
+```
+
+## Preprocessing Pipeline
+
+Run both parsing and DB loading in one command:
+
+```bash
+python3 util/preprocess-data.py ../test_images_labels_targets/test --output data-example
+```
+
+## Running the API
+
+If parsed images are not under `data-example`, point the API to the parser output root:
+
+```bash
+export PARSED_DATA_DIR='data-example'
+```
+
+```bash
+uvicorn app.main:app --reload
+```

--- a/readme.md
+++ b/readme.md
@@ -1,66 +1,28 @@
 # Backend
 
-## Setup
-
-Recommended to use [uv](https://docs.astral.sh/uv/getting-started/installation/) to manage virtual environment and pip packages.
-
-### First Installation
-
-Create virtual environment:
+## Quick Start
 
 ```bash
-uv venv
+cp .env.example .env
+# edit .env and fill in GEMINI_API_KEY and any other values you need
+make dev
 ```
 
-Install dependencies:
+Once the stack is up, `GET http://localhost:8000/health` should return 200.
 
-```bash
-uv pip install -r requirements.txt
-```
+## Environment
 
-## PostgreSQL + PostGIS
+All environment variables the backend reads are listed in [`.env.example`](./.env.example). That file is the canonical reference — one variable per line, grouped by concern (database, Gemini, preprocessing, Supabase image storage, CORS).
 
-Note: The following names and passwords are only for development purposes, and will be different in production.
+## Common tasks
 
-Create a PostgreSQL database with PostGIS enabled, then set:
+- `make dev` — build and run the full stack (api + db) via docker compose
+- `make db` — start only the Postgres/PostGIS container
+- `make seed` — run `util/seed_minimal.py`
+- `make test` — run pytest
+- `make eval` — run the VLM evaluation against `hurricane-florence`
+- `make lint` — run `ruff check .` and `black --check .`
 
-```bash
-docker run --name utd-postgis \
-    -e POSTGRES_USER=utd \
-    -e POSTGRES_PASSWORD=utdpass \
-    -e POSTGRES_DB=utd_data \
-    -p 5432:5432 \
-    -d postgis/postgis:16-3.4
-```
+---
 
-If this not the first time running, use now:
-
-```bash
-docker start utd-postgis
-```
-
-Make sure your environment has the variable DATABASE_URL which corresponds to the new DB.
-
-```bash
-export DATABASE_URL='postgresql+psycopg://utd:utdpass@localhost:5432/utd_data'
-```
-
-## Preprocessing Pipeline
-
-Run both parsing and DB loading in one command:
-
-```bash
-python3 util/preprocess-data.py ../test_images_labels_targets/test --output data-example
-```
-
-## Running the API
-
-If parsed images are not under `data-example`, point the API to the parser output root:
-
-```bash
-export PARSED_DATA_DIR='data-example'
-```
-
-```bash
-uvicorn app.main:app --reload
-```
+For the non-Docker flow (manual uv + raw `docker run`), see [docs/manual-setup.md](./docs/manual-setup.md).


### PR DESCRIPTION
Closes #59.

Lets anyone clone the backend and get it running with two commands: copy the example env file, then run `make dev`.

## What is new
- `Dockerfile` and `docker-compose.yml` spin up Postgres (with PostGIS on host port 5433) and the API in one step. The API waits for the database to be healthy before starting.
- `.env.example` lists every environment variable the app reads, grouped by section, with safe local defaults and no real secrets.
- `Makefile` with common tasks: `dev`, `db`, `seed`, `test`, `eval`, `lint`. The `dev` target also creates the `.env` file from the example on first run and tells you to fill in the Gemini API key before continuing.
- `app/config.py` checks required env vars at startup and fails fast with a readable error if `DATABASE_URL` or `GEMINI_API_KEY` are missing.
- `README` rewritten as Quick Start, Environment, and Common tasks. The original manual `uv` + plain `docker run` flow is preserved at `docs/manual-setup.md`.

## What is NOT in this PR
- No existing Python code is refactored.
- No new Python dependencies.
- No CI, pre-commit hooks, or linters.
- No database migration tooling (that ships in a separate PR).

## Test plan
- [ ] Fresh clone, `cp .env.example .env`, fill in `GEMINI_API_KEY`, run `make dev`.
- [ ] `curl http://127.0.0.1:8000/health` returns `200 OK`.
- [ ] Delete `.env` and run `make dev` to confirm the bootstrap message.
- [ ] Start the app with `DATABASE_URL` unset and confirm it fails fast with a clear message.