### PR TITLE
feat: disaster summary and hotspot endpoints (#67)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -224,6 +224,131 @@ async def get_locations(
     return {"features": features}
 
 
+_HOTSPOT_MIN_CLUSTER_SIZE = 10
+
+_NORMALIZED_DAMAGE_SQL = """
+        COALESCE(
+            CASE a.damage_level
+                WHEN 'no-damage' THEN 'none'
+                WHEN 'minor-damage' THEN 'minor'
+                WHEN 'major-damage' THEN 'severe'
+                WHEN 'destroyed' THEN 'destroyed'
+                WHEN 'unknown' THEN 'unknown'
+                ELSE a.damage_level
+            END,
+            l.classification
+        )
+"""
+
+
+@app.get("/disasters/{disaster_id}/summary")
+async def get_disaster_summary(disaster_id: str) -> dict[str, object]:
+    query = f"""
+        SELECT
+            COUNT(*) AS total_locations,
+            COUNT(*) FILTER (WHERE {_NORMALIZED_DAMAGE_SQL} = 'none') AS none_count,
+            COUNT(*) FILTER (WHERE {_NORMALIZED_DAMAGE_SQL} = 'minor') AS minor_count,
+            COUNT(*) FILTER (WHERE {_NORMALIZED_DAMAGE_SQL} = 'severe') AS severe_count,
+            COUNT(*) FILTER (WHERE {_NORMALIZED_DAMAGE_SQL} = 'destroyed') AS destroyed_count,
+            COUNT(*) FILTER (WHERE {_NORMALIZED_DAMAGE_SQL} = 'unknown') AS unknown_count,
+            MIN(ST_Y(l.centroid)) AS min_lat,
+            MAX(ST_Y(l.centroid)) AS max_lat,
+            MIN(ST_X(l.centroid)) AS min_lng,
+            MAX(ST_X(l.centroid)) AS max_lng
+        FROM locations AS l
+        JOIN image_pairs AS ip ON ip.id = l.image_pair_id
+        LEFT JOIN chat.vlm_assessments AS a ON a.location_id = l.id
+        WHERE ip.disaster_id = :disaster_id
+    """
+
+    engine = get_engine()
+    with engine.connect() as conn:
+        row = (
+            conn.execute(text(query), {"disaster_id": disaster_id}).mappings().first()
+        )
+
+    if row is None or not row["total_locations"]:
+        raise HTTPException(status_code=404, detail="disaster not found")
+
+    return {
+        "disaster_id": disaster_id,
+        "total_locations": int(row["total_locations"]),
+        "by_classification": {
+            "none": int(row["none_count"] or 0),
+            "minor": int(row["minor_count"] or 0),
+            "severe": int(row["severe_count"] or 0),
+            "destroyed": int(row["destroyed_count"] or 0),
+            "unknown": int(row["unknown_count"] or 0),
+        },
+        "bbox": {
+            "minLat": row["min_lat"],
+            "minLng": row["min_lng"],
+            "maxLat": row["max_lat"],
+            "maxLng": row["max_lng"],
+        },
+    }
+
+
+@app.get("/locations/hotspots")
+async def get_location_hotspots(
+    disaster_id: str = Query(...),
+    limit: int = Query(10, ge=1, le=50),
+) -> dict[str, list[dict[str, object]]]:
+    query = f"""
+        SELECT
+            round(ST_Y(l.centroid)::numeric, 2) AS lat_bin,
+            round(ST_X(l.centroid)::numeric, 2) AS lng_bin,
+            COUNT(*) FILTER (WHERE {_NORMALIZED_DAMAGE_SQL} = 'severe') AS severe_count,
+            COUNT(*) FILTER (WHERE {_NORMALIZED_DAMAGE_SQL} = 'destroyed') AS destroyed_count,
+            COUNT(*) AS total_count
+        FROM locations AS l
+        JOIN image_pairs AS ip ON ip.id = l.image_pair_id
+        LEFT JOIN chat.vlm_assessments AS a ON a.location_id = l.id
+        WHERE ip.disaster_id = :disaster_id
+          AND l.centroid IS NOT NULL
+        GROUP BY lat_bin, lng_bin
+        HAVING (
+            COUNT(*) FILTER (WHERE {_NORMALIZED_DAMAGE_SQL} = 'severe')
+          + COUNT(*) FILTER (WHERE {_NORMALIZED_DAMAGE_SQL} = 'destroyed')
+        ) > 0
+        AND COUNT(*) >= {_HOTSPOT_MIN_CLUSTER_SIZE}
+        ORDER BY
+            (
+                COUNT(*) FILTER (WHERE {_NORMALIZED_DAMAGE_SQL} = 'severe')
+              + COUNT(*) FILTER (WHERE {_NORMALIZED_DAMAGE_SQL} = 'destroyed')
+            ) DESC,
+            COUNT(*) FILTER (WHERE {_NORMALIZED_DAMAGE_SQL} = 'destroyed') DESC
+        LIMIT :limit
+    """
+
+    engine = get_engine()
+    with engine.connect() as conn:
+        rows = (
+            conn.execute(
+                text(query),
+                {"disaster_id": disaster_id, "limit": limit},
+            )
+            .mappings()
+            .all()
+        )
+
+    hotspots: list[dict[str, object]] = []
+    for row in rows:
+        severe = int(row["severe_count"] or 0)
+        destroyed = int(row["destroyed_count"] or 0)
+        hotspots.append(
+            {
+                "lat": float(row["lat_bin"]),
+                "lng": float(row["lng_bin"]),
+                "severe": severe,
+                "destroyed": destroyed,
+                "total": int(row["total_count"] or 0),
+            }
+        )
+
+    return {"hotspots": hotspots}
+
+
 @app.get("/image-pairs")
 async def get_image_pairs(
     request: Request,

--- a/tests/test_summary_endpoints.py
+++ b/tests/test_summary_endpoints.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import os
+from contextlib import contextmanager
+from typing import Any, Iterator
+from unittest.mock import patch
+
+import pytest
+
+# conftest.py in this repo does not provide a DB fixture, so we mock the
+# engine instead of spinning up Postgres for this PR. Follows the same
+# _FakeEngine / _FakeConn / _FakeResult pattern used in
+# tests/test_locations_address.py.
+
+os.environ.setdefault(
+    "DATABASE_URL", "postgresql+psycopg://test:test@localhost:5432/test"
+)
+os.environ.setdefault("GEMINI_API_KEY", "test-key")
+
+from fastapi.testclient import TestClient
+
+from app import main as app_main
+
+
+class _FakeResult:
+    def __init__(self, rows: list[dict[str, Any]]) -> None:
+        self._rows = rows
+
+    def mappings(self) -> "_FakeResult":
+        return self
+
+    def all(self) -> list[dict[str, Any]]:
+        return list(self._rows)
+
+    def first(self) -> dict[str, Any] | None:
+        return self._rows[0] if self._rows else None
+
+
+class _FakeConn:
+    def __init__(self, rows: list[dict[str, Any]]) -> None:
+        self._rows = rows
+
+    def execute(
+        self, _stmt: Any, _params: dict[str, Any] | None = None
+    ) -> _FakeResult:
+        return _FakeResult(self._rows)
+
+
+class _FakeEngine:
+    def __init__(self, rows: list[dict[str, Any]]) -> None:
+        self._rows = rows
+
+    @contextmanager
+    def connect(self) -> Iterator[_FakeConn]:
+        yield _FakeConn(self._rows)
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(app_main.app)
+
+
+def test_disaster_summary_returns_documented_shape(client: TestClient) -> None:
+    # The production SQL returns exactly one aggregated row. The fake engine
+    # returns that row verbatim to confirm the Python-side shaping.
+    summary_row = {
+        "total_locations": 11548,
+        "none_count": 8125,
+        "minor_count": 781,
+        "severe_count": 2196,
+        "destroyed_count": 410,
+        "unknown_count": 36,
+        "min_lat": 33.4,
+        "max_lat": 34.8,
+        "min_lng": -79.3,
+        "max_lng": -78.2,
+    }
+    with patch.object(
+        app_main, "get_engine", return_value=_FakeEngine([summary_row])
+    ):
+        resp = client.get("/disasters/hurricane-florence/summary")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body == {
+        "disaster_id": "hurricane-florence",
+        "total_locations": 11548,
+        "by_classification": {
+            "none": 8125,
+            "minor": 781,
+            "severe": 2196,
+            "destroyed": 410,
+            "unknown": 36,
+        },
+        "bbox": {
+            "minLat": 33.4,
+            "minLng": -79.3,
+            "maxLat": 34.8,
+            "maxLng": -78.2,
+        },
+    }
+
+
+def test_disaster_summary_missing_returns_404(client: TestClient) -> None:
+    # When the disaster_id is not present, the aggregate query still returns
+    # one row but with total=0 (and null min/max). The endpoint must 404.
+    empty_row = {
+        "total_locations": 0,
+        "none_count": 0,
+        "minor_count": 0,
+        "severe_count": 0,
+        "destroyed_count": 0,
+        "unknown_count": 0,
+        "min_lat": None,
+        "max_lat": None,
+        "min_lng": None,
+        "max_lng": None,
+    }
+    with patch.object(
+        app_main, "get_engine", return_value=_FakeEngine([empty_row])
+    ):
+        resp = client.get("/disasters/does-not-exist/summary")
+
+    assert resp.status_code == 404
+    assert resp.json() == {"detail": "disaster not found"}
+
+
+def test_locations_hotspots_respects_limit_and_order(client: TestClient) -> None:
+    # The SQL does the ORDER BY and LIMIT; we pre-sort the fake rows to match
+    # what the DB would return. The endpoint then trusts the DB ordering.
+    rows = [
+        {
+            "lat_bin": 33.70,
+            "lng_bin": -78.90,
+            "severe_count": 42,
+            "destroyed_count": 18,
+            "total_count": 74,
+        },
+        {
+            "lat_bin": 33.71,
+            "lng_bin": -78.91,
+            "severe_count": 30,
+            "destroyed_count": 12,
+            "total_count": 55,
+        },
+        {
+            "lat_bin": 33.72,
+            "lng_bin": -78.92,
+            "severe_count": 20,
+            "destroyed_count": 5,
+            "total_count": 40,
+        },
+    ]
+    with patch.object(app_main, "get_engine", return_value=_FakeEngine(rows)):
+        resp = client.get(
+            "/locations/hotspots",
+            params={"disaster_id": "hurricane-florence", "limit": 3},
+        )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "hotspots" in body
+    hotspots = body["hotspots"]
+    assert len(hotspots) <= 3
+    # Verify shape of the first bin and the severe+destroyed desc ordering.
+    assert hotspots[0] == {
+        "lat": 33.70,
+        "lng": -78.90,
+        "severe": 42,
+        "destroyed": 18,
+        "total": 74,
+    }
+    scores = [h["severe"] + h["destroyed"] for h in hotspots]
+    assert scores == sorted(scores, reverse=True)


### PR DESCRIPTION
Closes #67. Pairs with UTDisaster/frontend#47 and #49.

Adds two small read-only endpoints so the frontend can show the full Florence picture and land on real damage areas instead of an empty default.

## What is new
- **`GET /disasters/{id}/summary`** returns `{disaster_id, total_locations, by_classification{none,minor,severe,destroyed,unknown}, bbox}`. Returns **404** when the disaster has no locations.
- **`GET /locations/hotspots?disaster_id=...&limit=10`** returns up to 50 top lat/lng bins rounded to ~1 km, filtered to bins with severe + destroyed counts > 0 and at least 10 total locations, ordered by severe + destroyed desc then destroyed desc. Skips rows with NULL centroid.
- Both endpoints reuse the same VLM-normalized damage level already used by `/locations` (`no-damage → none`, `minor-damage → minor`, etc.) via a shared `_NORMALIZED_DAMAGE_SQL` snippet.

## What is NOT in this PR
- No schema changes.
- No caching, no rate-limiting, no pagination beyond the hardcoded limit cap.
- No `event_window` in the summary (the `disasters` table has no date columns yet).
- No refactor of the existing `/locations` handler.

## Test plan
- [ ] `pytest tests/test_summary_endpoints.py -v` passes 3/3.
- [ ] `pytest` full suite passes 35/35 with no regressions.
- [ ] `curl /disasters/hurricane-florence/summary` on local docker returns the expected shape with real counts.
- [ ] `curl /disasters/nonsense/summary` returns 404.
- [ ] `curl /locations/hotspots?disaster_id=hurricane-florence&limit=5` returns up to 5 bins in descending severity order.
- [ ] Missing `disaster_id` returns 422.
- [ ] `limit=99999` is rejected with 422 (server-side cap at 50).