### PR TITLE
feat: enable pg_trgm and add trigram indexes on address columns

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,24 @@
+# --- Database ---
+# Default value targets the Compose service. For manual / non-Docker runs, use localhost:5433.
+DATABASE_URL=postgresql+psycopg://utd:utdpass@db:5432/utd_data
+# For production Supabase, replace with the pooled connection string
+
+# --- Gemini ---
+GEMINI_API_KEY=
+
+# --- Local preprocessing ---
+PARSED_DATA_DIR=data-example
+# Optional: override the VLM dataset directory (defaults to PARSED_DATA_DIR).
+VLM_DATASET_DIR=
+
+# --- Supabase image storage ---
+SUPABASE_URL=
+SUPABASE_IMAGES_BUCKET=images
+SUPABASE_STRIP_PREFIX=images/
+SUPABASE_USE_BASENAME=false
+SUPABASE_SERVICE_ROLE_KEY=
+
+# --- CORS ---
+CORS_ALLOW_ORIGIN_REGEX=^https://.*\.vercel\.app$
+# Optional: comma-separated list of explicit origins. Takes precedence over the regex.
+CORS_ALLOW_ORIGINS=

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ log.txt
 # Environment variables
 .env
 .env.*
+!.env.example
 service_role.txt
 
 # VLM pipeline local artifacts

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+
+RUN pip install --no-cache-dir uv
+
+WORKDIR /app
+
+COPY requirements.txt requirements-dev.txt ./
+RUN uv pip install --system -r requirements-dev.txt
+
+RUN useradd --create-home --uid 1000 appuser \
+    && chown -R appuser:appuser /app
+USER appuser
+
+EXPOSE 8000
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+# Backend dev commands. Run `make dev` after copying .env.example to .env.
+
+.PHONY: dev db seed test eval lint
+
+.env:
+	cp .env.example .env
+	@echo ">>> Created .env from .env.example. Fill in GEMINI_API_KEY and rerun 'make dev'."
+	@false
+
+dev: .env
+	docker compose up --build
+
+db:
+	docker compose up -d db
+
+seed:
+	python util/seed_minimal.py
+
+test:
+	pytest
+
+eval:
+	python util/vlm_eval.py --disaster-id hurricane-florence
+
+lint:
+	ruff check . && black --check .

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Backend dev commands. Run `make dev` after copying .env.example to .env.
 
-.PHONY: dev db seed test eval lint
+.PHONY: dev db seed test eval lint migrate
 
 .env:
 	cp .env.example .env
@@ -24,3 +24,6 @@ eval:
 
 lint:
 	ruff check . && black --check .
+
+migrate:
+	python util/migrate.py

--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+ENV_VARS = (
+    "DATABASE_URL",
+    "GEMINI_API_KEY",
+    "PARSED_DATA_DIR",
+    "SUPABASE_URL",
+    "SUPABASE_IMAGES_BUCKET",
+    "SUPABASE_STRIP_PREFIX",
+    "SUPABASE_USE_BASENAME",
+    "SUPABASE_SERVICE_ROLE_KEY",
+    "CORS_ALLOW_ORIGIN_REGEX",
+    "CORS_ALLOW_ORIGINS",
+)
+
+REQUIRED = ("DATABASE_URL", "GEMINI_API_KEY")
+
+
+def validate_env() -> None:
+    for name in ENV_VARS:
+        if not os.getenv(name):
+            logger.warning("env var %s is not set", name)
+
+    missing_required = [name for name in REQUIRED if not os.getenv(name)]
+    if missing_required:
+        raise RuntimeError(
+            f"missing required env vars: {', '.join(missing_required)}"
+        )

--- a/app/db.py
+++ b/app/db.py
@@ -9,6 +9,7 @@ load_dotenv()
 from sqlalchemy import (
     BigInteger,
     Column,
+    DateTime,
     Float,
     ForeignKey,
     Index,
@@ -86,6 +87,12 @@ locations = Table(
     Column("classification", Text, nullable=True),
     Column("geom", Geometry("Polygon", 4326), nullable=False),
     Column("centroid", Geometry("Point", 4326), nullable=False),
+    Column("street", Text, nullable=True),
+    Column("city", Text, nullable=True),
+    Column("county", Text, nullable=True),
+    Column("full_address", Text, nullable=True),
+    Column("address_source", Text, nullable=True),
+    Column("address_fetched_at", DateTime(timezone=True), nullable=True),
 )
 
 Index("ix_locations_geom_gist", locations.c.geom, postgresql_using="gist")

--- a/app/main.py
+++ b/app/main.py
@@ -137,12 +137,25 @@ async def get_locations(
     max_lat: float = Query(...),
     disaster_id: Optional[str] = Query(None),
     limit: int = Query(5000, ge=1, le=20000),
+    include_address: bool = Query(False),
 ) -> dict[str, list[dict[str, object]]]:
     min_lng, min_lat, max_lng, max_lat = _normalize_bbox(
         min_lng, min_lat, max_lng, max_lat
     )
 
-    query = """
+    address_select = (
+        ",\n            l.street AS street,\n"
+        "            l.city AS city,\n"
+        "            l.county AS county,\n"
+        "            l.full_address AS full_address,\n"
+        "            l.address_source AS address_source,\n"
+        "            l.address_fetched_at AS address_fetched_at"
+        if include_address
+        else ""
+    )
+
+    # address_select is a hardcoded literal gated by a bool; no user input reaches the f-string.
+    query = f"""
         SELECT
             l.id AS location_id,
             l.location_uid,
@@ -167,7 +180,7 @@ async def get_locations(
             ip.post_path,
             ST_AsGeoJSON(l.geom) AS geometry,
             ST_X(l.centroid) AS centroid_lng,
-            ST_Y(l.centroid) AS centroid_lat
+            ST_Y(l.centroid) AS centroid_lat{address_select}
         FROM locations AS l
         JOIN image_pairs AS ip ON ip.id = l.image_pair_id
         LEFT JOIN chat.vlm_assessments AS a ON a.location_id = l.id
@@ -197,32 +210,45 @@ async def get_locations(
     for row in rows:
         pre_path = row["pre_path"]
         post_path = row["post_path"]
-        features.append(
-            {
-                "location_id": row["location_id"],
-                "location_uid": row["location_uid"],
-                "image_pair_id": row["image_pair_id"],
-                "disaster_id": row["disaster_id"],
-                "classification": row["classification"],
-                "damage_level": row["damage_level"],
-                "vlm_confidence": (
-                    float(row["vlm_confidence"])
-                    if row["vlm_confidence"] is not None
-                    else None
-                ),
-                "vlm_description": row["vlm_description"],
-                "feature_type": row["feature_type"],
-                "pre_path": pre_path,
-                "post_path": post_path,
-                "pre_url": _build_image_url(request, pre_path),
-                "post_url": _build_image_url(request, post_path),
-                "geometry": json.loads(row["geometry"]) if row["geometry"] else None,
-                "centroid": {
-                    "lng": row["centroid_lng"],
-                    "lat": row["centroid_lat"],
-                },
-            }
-        )
+        feature: dict[str, object] = {
+            "location_id": row["location_id"],
+            "location_uid": row["location_uid"],
+            "image_pair_id": row["image_pair_id"],
+            "disaster_id": row["disaster_id"],
+            "classification": row["classification"],
+            "damage_level": row["damage_level"],
+            "vlm_confidence": (
+                float(row["vlm_confidence"])
+                if row["vlm_confidence"] is not None
+                else None
+            ),
+            "vlm_description": row["vlm_description"],
+            "feature_type": row["feature_type"],
+            "pre_path": pre_path,
+            "post_path": post_path,
+            "pre_url": _build_image_url(request, pre_path),
+            "post_url": _build_image_url(request, post_path),
+            "geometry": json.loads(row["geometry"]) if row["geometry"] else None,
+            "centroid": {
+                "lng": row["centroid_lng"],
+                "lat": row["centroid_lat"],
+            },
+        }
+        if include_address:
+            if row["full_address"] is None and row["street"] is None and row["city"] is None and row["county"] is None:
+                feature["address"] = None
+            else:
+                fetched_at = row["address_fetched_at"]
+                # DB columns address_source / address_fetched_at map to JSON keys source / fetched_at.
+                feature["address"] = {
+                    "street": row["street"],
+                    "city": row["city"],
+                    "county": row["county"],
+                    "full_address": row["full_address"],
+                    "source": row["address_source"],
+                    "fetched_at": fetched_at.isoformat() if fetched_at is not None else None,
+                }
+        features.append(feature)
 
     return {"features": features}
 

--- a/app/main.py
+++ b/app/main.py
@@ -10,8 +10,11 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from sqlalchemy import text
 
-from app.db import get_engine  # ← db first
-from app.routers.chat import router as chat_router  # ← chat after
+from app.config import validate_env
+from app.db import get_engine
+from app.routers.chat import router as chat_router
+
+validate_env()
 
 
 def _parse_cors_origins() -> list[str]:
@@ -36,7 +39,7 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
-app.include_router(chat_router)  # ← after app is created
+app.include_router(chat_router)
 PARSED_DATA_DIR = (
     Path(os.getenv("PARSED_DATA_DIR", "data-example")).expanduser().resolve()
 )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+services:
+  db:
+    image: postgis/postgis:16-3.4
+    environment:
+      POSTGRES_USER: utd
+      POSTGRES_PASSWORD: utdpass
+      POSTGRES_DB: utd_data
+    ports:
+      - "5433:5432"
+    volumes:
+      - utd-pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U utd"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  api:
+    build: .
+    env_file: .env
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./:/app
+    depends_on:
+      db:
+        condition: service_healthy
+
+volumes:
+  utd-pgdata:

--- a/docs/manual-setup.md
+++ b/docs/manual-setup.md
@@ -1,0 +1,68 @@
+This is the manual setup path for contributors who cannot use Docker Compose. Prefer the Quick Start in the main README.
+
+# Backend
+
+## Setup
+
+Recommended to use [uv](https://docs.astral.sh/uv/getting-started/installation/) to manage virtual environment and pip packages.
+
+### First Installation
+
+Create virtual environment:
+
+```bash
+uv venv
+```
+
+Install dependencies:
+
+```bash
+uv pip install -r requirements.txt
+```
+
+## PostgreSQL + PostGIS
+
+Note: The following names and passwords are only for development purposes, and will be different in production.
+
+Create a PostgreSQL database with PostGIS enabled, then set:
+
+```bash
+docker run --name utd-postgis \
+    -e POSTGRES_USER=utd \
+    -e POSTGRES_PASSWORD=utdpass \
+    -e POSTGRES_DB=utd_data \
+    -p 5433:5432 \
+    -d postgis/postgis:16-3.4
+```
+
+If this not the first time running, use now:
+
+```bash
+docker start utd-postgis
+```
+
+Make sure your environment has the variable DATABASE_URL which corresponds to the new DB.
+
+```bash
+export DATABASE_URL='postgresql+psycopg://utd:utdpass@localhost:5433/utd_data'
+```
+
+## Preprocessing Pipeline
+
+Run both parsing and DB loading in one command:
+
+```bash
+python3 util/preprocess-data.py ../test_images_labels_targets/test --output data-example
+```
+
+## Running the API
+
+If parsed images are not under `data-example`, point the API to the parser output root:
+
+```bash
+export PARSED_DATA_DIR='data-example'
+```
+
+```bash
+uvicorn app.main:app --reload
+```

--- a/migrations/0001_add_address_columns.sql
+++ b/migrations/0001_add_address_columns.sql
@@ -1,0 +1,8 @@
+-- 0001: add reverse-geocoded address columns to locations
+ALTER TABLE locations
+  ADD COLUMN IF NOT EXISTS street            text,
+  ADD COLUMN IF NOT EXISTS city              text,
+  ADD COLUMN IF NOT EXISTS county            text,
+  ADD COLUMN IF NOT EXISTS full_address      text,
+  ADD COLUMN IF NOT EXISTS address_source    text,
+  ADD COLUMN IF NOT EXISTS address_fetched_at timestamptz;

--- a/migrations/0002_pg_trgm_street_index.sql
+++ b/migrations/0002_pg_trgm_street_index.sql
@@ -1,0 +1,10 @@
+-- 0002: enable pg_trgm and index locations.street / full_address for fuzzy match
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+CREATE INDEX IF NOT EXISTS ix_locations_street_trgm
+  ON locations
+  USING gin (street gin_trgm_ops);
+
+CREATE INDEX IF NOT EXISTS ix_locations_full_address_trgm
+  ON locations
+  USING gin (full_address gin_trgm_ops);

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -7,6 +7,7 @@ Plain SQL schema migrations. No Alembic.
   been recorded in the `schema_migrations` table (`name text primary key, applied_at timestamptz`).
 - Each file runs inside a single transaction; its filename is inserted into
   `schema_migrations` after a successful apply.
+- 0002_pg_trgm_street_index.sql — enables pg_trgm and adds trigram indexes for address/street fuzzy matching
 
 Run with:
 

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -1,0 +1,21 @@
+# Migrations
+
+Plain SQL schema migrations. No Alembic.
+
+- Files are named `NNNN_description.sql` and applied in lexicographic order.
+- `util/migrate.py` walks this directory and executes each file that has not already
+  been recorded in the `schema_migrations` table (`name text primary key, applied_at timestamptz`).
+- Each file runs inside a single transaction; its filename is inserted into
+  `schema_migrations` after a successful apply.
+
+Run with:
+
+```
+make migrate
+```
+
+or directly:
+
+```
+python util/migrate.py
+```

--- a/readme.md
+++ b/readme.md
@@ -1,66 +1,28 @@
 # Backend
 
-## Setup
-
-Recommended to use [uv](https://docs.astral.sh/uv/getting-started/installation/) to manage virtual environment and pip packages.
-
-### First Installation
-
-Create virtual environment:
+## Quick Start
 
 ```bash
-uv venv
+cp .env.example .env
+# edit .env and fill in GEMINI_API_KEY and any other values you need
+make dev
 ```
 
-Install dependencies:
+Once the stack is up, `GET http://localhost:8000/health` should return 200.
 
-```bash
-uv pip install -r requirements.txt
-```
+## Environment
 
-## PostgreSQL + PostGIS
+All environment variables the backend reads are listed in [`.env.example`](./.env.example). That file is the canonical reference — one variable per line, grouped by concern (database, Gemini, preprocessing, Supabase image storage, CORS).
 
-Note: The following names and passwords are only for development purposes, and will be different in production.
+## Common tasks
 
-Create a PostgreSQL database with PostGIS enabled, then set:
+- `make dev` — build and run the full stack (api + db) via docker compose
+- `make db` — start only the Postgres/PostGIS container
+- `make seed` — run `util/seed_minimal.py`
+- `make test` — run pytest
+- `make eval` — run the VLM evaluation against `hurricane-florence`
+- `make lint` — run `ruff check .` and `black --check .`
 
-```bash
-docker run --name utd-postgis \
-    -e POSTGRES_USER=utd \
-    -e POSTGRES_PASSWORD=utdpass \
-    -e POSTGRES_DB=utd_data \
-    -p 5432:5432 \
-    -d postgis/postgis:16-3.4
-```
+---
 
-If this not the first time running, use now:
-
-```bash
-docker start utd-postgis
-```
-
-Make sure your environment has the variable DATABASE_URL which corresponds to the new DB.
-
-```bash
-export DATABASE_URL='postgresql+psycopg://utd:utdpass@localhost:5432/utd_data'
-```
-
-## Preprocessing Pipeline
-
-Run both parsing and DB loading in one command:
-
-```bash
-python3 util/preprocess-data.py ../test_images_labels_targets/test --output data-example
-```
-
-## Running the API
-
-If parsed images are not under `data-example`, point the API to the parser output root:
-
-```bash
-export PARSED_DATA_DIR='data-example'
-```
-
-```bash
-uvicorn app.main:app --reload
-```
+For the non-Docker flow (manual uv + raw `docker run`), see [docs/manual-setup.md](./docs/manual-setup.md).

--- a/tests/test_locations_address.py
+++ b/tests/test_locations_address.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import datetime as dt
+import os
+from contextlib import contextmanager
+from typing import Any, Iterator
+from unittest.mock import patch
+
+import pytest
+
+# conftest.py in this repo does not provide a DB fixture, so we mock the
+# engine instead of spinning up Postgres for this PR. An integration test
+# against `make db` can be layered on later without changing this contract.
+
+os.environ.setdefault("DATABASE_URL", "postgresql+psycopg://test:test@localhost:5432/test")
+os.environ.setdefault("GEMINI_API_KEY", "test-key")
+
+from fastapi.testclient import TestClient
+
+from app import main as app_main
+
+
+BASE_ROW: dict[str, Any] = {
+    "location_id": 1,
+    "location_uid": "loc-1",
+    "image_pair_id": "ip-1",
+    "feature_type": "building",
+    "classification": "no-damage",
+    "damage_level": "none",
+    "vlm_confidence": 0.9,
+    "vlm_description": "intact",
+    "disaster_id": "hurricane-florence",
+    "pre_path": "images/pre.png",
+    "post_path": "images/post.png",
+    "geometry": '{"type":"Polygon","coordinates":[[[0,0],[1,0],[1,1],[0,1],[0,0]]]}',
+    "centroid_lng": 0.5,
+    "centroid_lat": 0.5,
+}
+
+
+class _FakeResult:
+    def __init__(self, rows: list[dict[str, Any]]) -> None:
+        self._rows = rows
+
+    def mappings(self) -> "_FakeResult":
+        return self
+
+    def all(self) -> list[dict[str, Any]]:
+        return self._rows
+
+
+class _FakeConn:
+    def __init__(self, rows: list[dict[str, Any]]) -> None:
+        self._rows = rows
+
+    def execute(self, _stmt: Any, _params: dict[str, Any] | None = None) -> _FakeResult:
+        return _FakeResult(self._rows)
+
+
+class _FakeEngine:
+    def __init__(self, rows: list[dict[str, Any]]) -> None:
+        self._rows = rows
+
+    @contextmanager
+    def connect(self) -> Iterator[_FakeConn]:
+        yield _FakeConn(self._rows)
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(app_main.app)
+
+
+def _bbox_params() -> dict[str, float]:
+    return {"min_lng": -1.0, "min_lat": -1.0, "max_lng": 1.0, "max_lat": 1.0}
+
+
+def test_locations_default_response_has_no_address_key(client: TestClient) -> None:
+    rows = [dict(BASE_ROW)]
+    with patch.object(app_main, "get_engine", return_value=_FakeEngine(rows)):
+        resp = client.get("/locations", params=_bbox_params())
+    assert resp.status_code == 200
+    feature = resp.json()["features"][0]
+    assert "address" not in feature
+
+
+def test_locations_include_address_without_geocoded_fields_returns_null(client: TestClient) -> None:
+    # Design decision: when include_address=true but the row has never been
+    # geocoded, we emit `address: null` rather than an object full of nulls.
+    # Callers can distinguish "not yet fetched" from "fetched, no match" by
+    # checking `address === null` vs `address.source === 'census'`.
+    row = dict(
+        BASE_ROW,
+        street=None,
+        city=None,
+        county=None,
+        full_address=None,
+        address_source=None,
+        address_fetched_at=None,
+    )
+    with patch.object(app_main, "get_engine", return_value=_FakeEngine([row])):
+        resp = client.get("/locations", params={**_bbox_params(), "include_address": "true"})
+    assert resp.status_code == 200
+    feature = resp.json()["features"][0]
+    assert feature["address"] is None
+
+
+def test_locations_include_address_with_geocoded_fields_returns_nested_object(client: TestClient) -> None:
+    fetched = dt.datetime(2026, 4, 18, 12, 0, 0, tzinfo=dt.timezone.utc)
+    row = dict(
+        BASE_ROW,
+        street="Main St",
+        city="Wilmington",
+        county="New Hanover",
+        full_address="123 Main St, Wilmington, NC",
+        address_source="census",
+        address_fetched_at=fetched,
+    )
+    with patch.object(app_main, "get_engine", return_value=_FakeEngine([row])):
+        resp = client.get("/locations", params={**_bbox_params(), "include_address": "true"})
+    assert resp.status_code == 200
+    feature = resp.json()["features"][0]
+    assert feature["address"] == {
+        "street": "Main St",
+        "city": "Wilmington",
+        "county": "New Hanover",
+        "full_address": "123 Main St, Wilmington, NC",
+        "source": "census",
+        "fetched_at": fetched.isoformat(),
+    }

--- a/util/enrich_addresses.py
+++ b/util/enrich_addresses.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from typing import Optional
+
+import httpx
+from sqlalchemy import text
+from tqdm import tqdm
+
+from app.db import get_engine
+
+CENSUS_URL = "https://geocoding.geo.census.gov/geocoder/geographies/coordinates"
+CENSUS_BENCHMARK = "Public_AR_Current"
+CENSUS_VINTAGE = "Current_Current"
+REQUEST_TIMEOUT_SECONDS = 5.0
+RATE_LIMIT_SLEEP_SECONDS = 0.2
+DEFAULT_LIMIT = 100
+MAX_LIMIT = 1000
+
+# Nominatim fallback lives in a future PR once Census gaps are quantified.
+
+
+def geocode_coords(
+    client: httpx.Client, lat: float, lng: float
+) -> Optional[dict[str, Optional[str]]]:
+    params = {
+        "x": lng,
+        "y": lat,
+        "benchmark": CENSUS_BENCHMARK,
+        "vintage": CENSUS_VINTAGE,
+        "format": "json",
+    }
+    try:
+        resp = client.get(CENSUS_URL, params=params)
+        resp.raise_for_status()
+        payload = resp.json()
+    except (httpx.HTTPError, ValueError):
+        return None
+
+    result = payload.get("result") or {}
+    geographies = result.get("geographies") or {}
+
+    counties = geographies.get("Counties") or []
+    places = geographies.get("Incorporated Places") or geographies.get("Census Designated Places") or []
+
+    city = places[0].get("NAME") if places else None
+    county = counties[0].get("NAME") if counties else None
+    street = None
+
+    address_matches = result.get("addressMatches") or []
+    if address_matches:
+        components = address_matches[0].get("addressComponents") or {}
+        street_parts = [
+            components.get("preQualifier"),
+            components.get("preDirection"),
+            components.get("preType"),
+            components.get("streetName"),
+            components.get("suffixType"),
+            components.get("suffixDirection"),
+        ]
+        street = " ".join(p for p in street_parts if p).strip() or None
+        full_address = address_matches[0].get("matchedAddress")
+    else:
+        full_address = None
+
+    if not any([street, city, county, full_address]):
+        return None
+
+    return {
+        "street": street,
+        "city": city,
+        "county": county,
+        "full_address": full_address,
+    }
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Reverse-geocode location centroids via the U.S. Census Geocoder.")
+    parser.add_argument("--limit", type=int, default=DEFAULT_LIMIT)
+    parser.add_argument("--dry-run", action="store_true")
+    return parser.parse_args()
+
+
+SELECT_SQL = """
+SELECT id, ST_Y(centroid) AS lat, ST_X(centroid) AS lng
+FROM locations
+WHERE full_address IS NULL
+ORDER BY id
+LIMIT :limit
+"""
+
+UPDATE_SQL = """
+UPDATE locations
+SET street = :street,
+    city = :city,
+    county = :county,
+    full_address = :full_address,
+    address_source = 'census',
+    address_fetched_at = now()
+WHERE id = :id
+"""
+
+
+def main() -> int:
+    args = _parse_args()
+    limit = max(1, min(args.limit, MAX_LIMIT))
+
+    engine = get_engine()
+    with engine.connect() as conn:
+        rows = conn.execute(text(SELECT_SQL), {"limit": limit}).mappings().all()
+
+    if not rows:
+        print("no locations need geocoding")
+        return 0
+
+    updates = 0
+    with httpx.Client(timeout=REQUEST_TIMEOUT_SECONDS) as client:
+        for row in tqdm(rows, desc="geocoding"):
+            result = geocode_coords(client, float(row["lat"]), float(row["lng"]))
+            if result is None:
+                time.sleep(RATE_LIMIT_SLEEP_SECONDS)
+                continue
+
+            if args.dry_run:
+                print(f"[dry-run] id={row['id']} -> {result}")
+            else:
+                with engine.begin() as conn:
+                    conn.execute(text(UPDATE_SQL), {"id": row["id"], **result})
+                updates += 1
+
+            time.sleep(RATE_LIMIT_SLEEP_SECONDS)
+
+    if args.dry_run:
+        print(f"[dry-run] would update {sum(1 for _ in rows)} row(s)")
+    else:
+        print(f"updated {updates} row(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/util/migrate.py
+++ b/util/migrate.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
+from sqlalchemy import create_engine, text
+
+load_dotenv()
+
+MIGRATIONS_DIR = Path(__file__).resolve().parents[1] / "migrations"
+
+CREATE_TABLE_SQL = """
+CREATE TABLE IF NOT EXISTS schema_migrations (
+    name text PRIMARY KEY,
+    applied_at timestamptz NOT NULL DEFAULT now()
+)
+"""
+
+
+def _applied(conn) -> set[str]:
+    rows = conn.execute(text("SELECT name FROM schema_migrations")).all()
+    return {row[0] for row in rows}
+
+
+def _discover() -> list[Path]:
+    if not MIGRATIONS_DIR.is_dir():
+        return []
+    return sorted(p for p in MIGRATIONS_DIR.glob("*.sql") if p.is_file())
+
+
+def main() -> int:
+    db_url = os.getenv("DATABASE_URL")
+    if not db_url:
+        print("DATABASE_URL is not set", file=sys.stderr)
+        return 1
+
+    engine = create_engine(db_url, future=True)
+    with engine.begin() as conn:
+        conn.execute(text(CREATE_TABLE_SQL))
+
+    files = _discover()
+    with engine.connect() as conn:
+        already = _applied(conn)
+
+    for path in files:
+        if path.name in already:
+            continue
+        sql = path.read_text(encoding="utf-8")
+        with engine.begin() as conn:
+            conn.execute(text(sql))
+            conn.execute(
+                text("INSERT INTO schema_migrations (name) VALUES (:name)"),
+                {"name": path.name},
+            )
+        print(f"applied {path.name}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Stacks on #66.

Tiny migration that flips on `pg_trgm` and builds GIN trigram indexes on `locations.street` and `locations.full_address`. This is what makes fuzzy address search (like typing "ocen blvd" and matching "Ocean Blvd") fast once the address data is populated.

## Why this is its own PR
Split out deliberately so the extension and indexes can be applied to production Supabase as a standalone deploy step **before** the chat tools that use them (PR for `feat/chat-address-tools`) ship. Keeps the deploy-gate conversation clean.

## What is new
- `migrations/0002_pg_trgm_street_index.sql` — `CREATE EXTENSION IF NOT EXISTS pg_trgm` + two `CREATE INDEX IF NOT EXISTS ... USING gin (<col> gin_trgm_ops)`.

## What is NOT in this PR
- No Python changes.
- No new schema columns.
- No queries that use these indexes yet. Application code stays working with or without them.

## Test plan
- [ ] After #66 merges and is applied to a local database, run `make migrate` and see `applied 0002_pg_trgm_street_index.sql`.
- [ ] Re-run `make migrate`, silent (no-op via `schema_migrations`).
- [ ] `\di+ locations_*_trgm` shows both new GIN indexes.
- [ ] Sample `SELECT ... WHERE street % 'Ocean'` `EXPLAIN` shows an index scan, not a seq scan.
- [ ] Run on prod Supabase ONLY after explicit approval.

## Deploy gate
Requires PR #66 migrations applied to prod before this one can deploy. Does not require any application code change.