### PR TITLE
feat: chat tools for address-aware damage lookups (frontend #51)

### DIFF
--- a/app/services/gemini.py
+++ b/app/services/gemini.py
@@ -11,6 +11,10 @@ from google.genai.errors import ClientError
 from sqlalchemy import text
 
 from app.db import get_engine
+from app.services.location_queries import (
+    lookup_damage_at_address,
+    nearby_damage,
+)
 
 load_dotenv()
 
@@ -202,7 +206,44 @@ TOOLS = [
             },
             "required": []
         }
-    }
+    },
+    {
+        "name": "lookup_damage_at_address",
+        "description": (
+            "Fuzzy-match an address, street name, house, or neighborhood/block string "
+            "and return damage aggregates for each matching group. "
+            "Use when the user asks about damage at a specific street, address, or neighborhood."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "Street name, address, or neighborhood text to match (min 4 chars).",
+                }
+            },
+            "required": ["query"],
+        },
+    },
+    {
+        "name": "nearby_damage",
+        "description": (
+            "Aggregate damage counts within a radius of a lat/lng point. "
+            "Use when the user asks what's damaged near a coordinate, point of interest, or block."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "lat": {"type": "number", "description": "Latitude of the center point"},
+                "lng": {"type": "number", "description": "Longitude of the center point"},
+                "radius_m": {
+                    "type": "integer",
+                    "description": "Search radius in meters. Clamped to [20, 5000]. Default 200.",
+                },
+            },
+            "required": ["lat", "lng"],
+        },
+    },
 ]
 
 
@@ -230,6 +271,21 @@ def _normalize_classification_filter(args: dict) -> dict:
         if alias is not None:
             out[alias] = bool(value)
     return out
+
+
+def _dominant_match(matches: list[dict]) -> dict | None:
+    """Return the top match if it's the only one or clearly dominates the runner-up."""
+    if not matches:
+        return None
+    if len(matches) == 1:
+        return matches[0]
+    top, runner = matches[0], matches[1]
+    top_score = float(top.get("score") or 0.0)
+    runner_score = float(runner.get("score") or 0.0)
+    # Dominant when the top score is meaningfully larger than the next candidate.
+    if top_score - runner_score >= 0.2:
+        return top
+    return None
 
 
 def _synthesize_reply_from_actions(actions: list[dict]) -> str:
@@ -420,12 +476,49 @@ def _run_tool(tool_name: str, args: dict) -> str:
             sanitized = _normalize_classification_filter(args)
             return json.dumps({"status": "ok", "filters": sanitized})
 
+        elif tool_name == "lookup_damage_at_address":
+            query = str(args.get("query") or "")
+            matches = lookup_damage_at_address(conn, query)
+            return json.dumps(
+                {
+                    "matches": [
+                        {
+                            "street": m.street,
+                            "city": m.city,
+                            "county": m.county,
+                            "total": m.total,
+                            "severe": m.severe,
+                            "destroyed": m.destroyed,
+                            "lat": m.lat,
+                            "lng": m.lng,
+                            "score": m.score,
+                        }
+                        for m in matches
+                    ]
+                }
+            )
+
+        elif tool_name == "nearby_damage":
+            lat = float(args["lat"])
+            lng = float(args["lng"])
+            radius_m = int(args.get("radius_m", 200))
+            agg = nearby_damage(conn, lat, lng, radius_m=radius_m)
+            return json.dumps(
+                {
+                    "none": agg.none,
+                    "minor": agg.minor,
+                    "severe": agg.severe,
+                    "destroyed": agg.destroyed,
+                    "unknown": agg.unknown,
+                }
+            )
+
     return json.dumps({"error": "Unknown tool"})
 
 
 # ── Main chat function ───────────────────────────────────────────────
 
-SYSTEM_PROMPT = """CRITICAL: If the user's message is not about disaster assessment, building damage, disaster information, hurricane facts, map navigation, or overlay/filter controls, respond ONLY with 'I can only help with disaster assessment and map navigation.' Do NOT call any tools for off-topic messages.
+SYSTEM_PROMPT = """CRITICAL: If the user's message is not about disaster assessment, building damage, disaster information, hurricane facts, map navigation, overlay/filter controls, or damage at a specific address, street, house, neighborhood, or block, respond ONLY with 'I can only help with disaster assessment and map navigation.' Do NOT call any tools for off-topic messages.
 
 You are a disaster assessment tool. You control a map interface showing building damage from satellite imagery.
 
@@ -435,9 +528,10 @@ Rules:
 - Use the tools to fetch data before answering questions about damage.
 - When navigating the map, just confirm the action briefly.
 - When adjusting overlays or filters, just confirm what changed.
-- Only respond to queries about disaster assessment, disaster information, hurricane facts, map navigation, overlays, filters, and building damage data.
+- Only respond to queries about disaster assessment, disaster information, hurricane facts, map navigation, overlays, filters, building damage data, and damage at a specific address, street, house, neighborhood, or block.
 - For unrelated questions, say: "I can only help with disaster assessment and map navigation."
 - To navigate to damaged areas: first call get_locations_by_damage to get coordinates, then call navigate_map with those lat/lng values.
+- For address/street/house/neighborhood/block queries, call lookup_damage_at_address with the user's query. For "what's damaged near here" or a coordinate, call nearby_damage. If no matches come back, say so briefly.
 
 Knowledge:
 - Hurricane Florence was a Category 4 hurricane that weakened to Category 1 at landfall.
@@ -571,6 +665,20 @@ def chat(
             result_data = json.loads(result_str)
             if not isinstance(result_data, dict):
                 result_data = {"result": result_data}
+
+            # Synthetic flyTo when an address lookup resolves to a single or
+            # clearly dominant match — let the map follow the answer.
+            if tool_name == "lookup_damage_at_address":
+                matches = result_data.get("matches") or []
+                top = _dominant_match(matches)
+                if top is not None:
+                    actions.append({
+                        "type": "flyTo",
+                        "lat": float(top["lat"]),
+                        "lng": float(top["lng"]),
+                        "zoom": 17,
+                    })
+
             fn_response_parts.append(
                 types.Part.from_function_response(
                     name=tool_name,

--- a/app/services/gemini.py
+++ b/app/services/gemini.py
@@ -499,8 +499,13 @@ def _run_tool(tool_name: str, args: dict) -> str:
             )
 
         elif tool_name == "nearby_damage":
-            lat = float(args["lat"])
-            lng = float(args["lng"])
+            try:
+                lat = float(args["lat"])
+                lng = float(args["lng"])
+            except (KeyError, TypeError, ValueError):
+                return json.dumps({"error": "lat and lng are required numeric fields"})
+            if not (-90.0 <= lat <= 90.0) or not (-180.0 <= lng <= 180.0):
+                return json.dumps({"error": "lat/lng out of valid geographic range"})
             radius_m = int(args.get("radius_m", 200))
             agg = nearby_damage(conn, lat, lng, radius_m=radius_m)
             return json.dumps(
@@ -671,7 +676,7 @@ def chat(
             if tool_name == "lookup_damage_at_address":
                 matches = result_data.get("matches") or []
                 top = _dominant_match(matches)
-                if top is not None:
+                if top is not None and top.get("lat") is not None and top.get("lng") is not None:
                     actions.append({
                         "type": "flyTo",
                         "lat": float(top["lat"]),

--- a/app/services/location_queries.py
+++ b/app/services/location_queries.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from sqlalchemy import text
+from sqlalchemy.engine import Connection
+
+
+@dataclass(frozen=True)
+class AddressMatch:
+    street: str | None
+    city: str | None
+    county: str | None
+    total: int
+    severe: int
+    destroyed: int
+    lat: float
+    lng: float
+    score: float
+
+
+@dataclass(frozen=True)
+class DamageAggregate:
+    none: int
+    minor: int
+    severe: int
+    destroyed: int
+    unknown: int
+
+
+# Below this length trigram matches return noise; at or above _LONG_QUERY_LEN
+# we match the full_address column rather than just street.
+_MIN_QUERY_LEN = 4
+_LONG_QUERY_LEN = 20
+_MAX_QUERY_LEN = 200
+_RADIUS_MIN_M, _RADIUS_MAX_M = 20, 5000
+
+# VLM-normalized damage_level with COALESCE fallback to locations.classification.
+_EFFECTIVE_LEVEL_SQL = """COALESCE(
+    CASE a.damage_level
+        WHEN 'no-damage' THEN 'none'
+        WHEN 'minor-damage' THEN 'minor'
+        WHEN 'major-damage' THEN 'severe'
+        WHEN 'destroyed' THEN 'destroyed'
+        WHEN 'unknown' THEN 'unknown'
+        ELSE a.damage_level
+    END,
+    l.classification,
+    'unknown'
+)"""
+
+
+def lookup_damage_at_address(
+    conn: Connection, query: str, *, limit: int = 5
+) -> list[AddressMatch]:
+    """Fuzzy-match an address/street string; aggregate damage per (street, city, county).
+
+    Short queries (< 4 chars) return []. Queries >= 20 chars match full_address;
+    shorter ones match street. Relies on pg_trgm indexes from the stacked migration.
+    """
+    q = (query or "").strip()[:_MAX_QUERY_LEN]
+    if len(q) < _MIN_QUERY_LEN:
+        return []
+    target = "l.full_address" if len(q) >= _LONG_QUERY_LEN else "l.street"
+    sql = text(f"""
+        SELECT l.street AS street, l.city AS city, l.county AS county,
+               COUNT(*) AS total,
+               COUNT(*) FILTER (WHERE {_EFFECTIVE_LEVEL_SQL} = 'severe') AS severe,
+               COUNT(*) FILTER (WHERE {_EFFECTIVE_LEVEL_SQL} = 'destroyed') AS destroyed,
+               AVG(ST_Y(l.centroid)) AS lat, AVG(ST_X(l.centroid)) AS lng,
+               MAX(similarity({target}, :q)) AS score
+        FROM locations l
+        LEFT JOIN chat.vlm_assessments a ON a.location_id = l.id
+        WHERE {target} %% :q
+        GROUP BY l.street, l.city, l.county
+        ORDER BY score DESC, total DESC
+        LIMIT :limit
+    """)
+    rows = conn.execute(sql, {"q": q, "limit": limit}).mappings().all()
+    return [
+        AddressMatch(
+            street=r["street"], city=r["city"], county=r["county"],
+            total=int(r["total"]), severe=int(r["severe"]), destroyed=int(r["destroyed"]),
+            lat=float(r["lat"]), lng=float(r["lng"]), score=float(r["score"]),
+        )
+        for r in rows
+    ]
+
+
+def nearby_damage(
+    conn: Connection, lat: float, lng: float, *, radius_m: int = 200
+) -> DamageAggregate:
+    """Aggregate damage counts within radius_m meters of (lat, lng). Radius clamped to [20, 5000]."""
+    clamped = max(_RADIUS_MIN_M, min(_RADIUS_MAX_M, int(radius_m)))
+    sql = text(f"""
+        SELECT {_EFFECTIVE_LEVEL_SQL} AS level, COUNT(*) AS n
+        FROM locations l
+        LEFT JOIN chat.vlm_assessments a ON a.location_id = l.id
+        WHERE ST_DWithin(
+            l.centroid::geography,
+            ST_SetSRID(ST_MakePoint(:lng, :lat), 4326)::geography,
+            :radius
+        )
+        GROUP BY 1
+    """)
+    rows = conn.execute(sql, {"lat": lat, "lng": lng, "radius": clamped}).mappings().all()
+    buckets = {"none": 0, "minor": 0, "severe": 0, "destroyed": 0, "unknown": 0}
+    for r in rows:
+        key = r["level"] if r["level"] in buckets else "unknown"
+        buckets[key] += int(r["n"])
+    return DamageAggregate(**buckets)

--- a/tests/test_chat_address_tools.py
+++ b/tests/test_chat_address_tools.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+import json
+import os
+from contextlib import contextmanager
+from typing import Any, Iterator
+from unittest.mock import patch
+
+import pytest
+
+os.environ.setdefault("DATABASE_URL", "postgresql+psycopg://test:test@localhost:5432/test")
+os.environ.setdefault("GEMINI_API_KEY", "test-key")
+
+from app.services import gemini as gemini_mod
+from app.services.location_queries import (
+    AddressMatch,
+    DamageAggregate,
+    lookup_damage_at_address,
+    nearby_damage,
+)
+
+
+# ── Fake SQLAlchemy-ish plumbing ─────────────────────────────────────
+
+
+class _FakeResult:
+    def __init__(self, rows: list[dict[str, Any]]) -> None: self._rows = rows
+    def mappings(self) -> "_FakeResult": return self
+    def all(self) -> list[dict[str, Any]]: return self._rows
+
+
+class _FakeConn:
+    def __init__(self, rows: list[dict[str, Any]]) -> None:
+        self._rows, self.calls = rows, []
+
+    def execute(self, _s: Any, params: dict[str, Any] | None = None) -> _FakeResult:
+        self.calls.append(dict(params or {}))
+        return _FakeResult(self._rows)
+
+
+class _FakeEngine:
+    def __init__(self, conn: _FakeConn) -> None: self._conn = conn
+
+    @contextmanager
+    def connect(self) -> Iterator[_FakeConn]:
+        yield self._conn
+
+
+def _row(**o: Any) -> dict[str, Any]:
+    return {
+        "street": "Ocean Blvd", "city": "Myrtle Beach", "county": "Horry",
+        "total": 12, "severe": 3, "destroyed": 1,
+        "lat": 33.69, "lng": -78.89, "score": 0.85, **o,
+    }
+
+
+# ── lookup_damage_at_address ─────────────────────────────────────────
+
+
+def test_lookup_exact_match_returns_top_row() -> None:
+    conn = _FakeConn([_row(score=0.95)])
+    out = lookup_damage_at_address(conn, "Ocean Blvd")
+    assert out == [AddressMatch(
+        street="Ocean Blvd", city="Myrtle Beach", county="Horry",
+        total=12, severe=3, destroyed=1, lat=33.69, lng=-78.89, score=0.95,
+    )]
+    assert conn.calls[0]["q"] == "Ocean Blvd"
+
+
+def test_lookup_fuzzy_match_keeps_trigram_ordering() -> None:
+    # Caller receives rows in the order the DB ranked them by similarity.
+    rows = [_row(street="Ocean Blvd", score=0.62), _row(street="Ocala Ave", score=0.31)]
+    out = lookup_damage_at_address(_FakeConn(rows), "Ocen Blvd")
+    assert [m.street for m in out] == ["Ocean Blvd", "Ocala Ave"]
+
+
+def test_lookup_short_query_returns_empty_and_skips_db() -> None:
+    conn = _FakeConn([])
+    assert lookup_damage_at_address(conn, "Oc") == []
+    assert lookup_damage_at_address(conn, "   ") == []
+    assert conn.calls == []
+
+
+# ── nearby_damage ────────────────────────────────────────────────────
+
+
+def test_nearby_damage_aggregates_buckets() -> None:
+    rows = [
+        {"level": "none", "n": 2},
+        {"level": "minor", "n": 1},
+        {"level": "severe", "n": 3},
+        {"level": "destroyed", "n": 1},
+        {"level": "unknown", "n": 1},
+    ]
+    conn = _FakeConn(rows)
+    agg = nearby_damage(conn, lat=33.69, lng=-78.89, radius_m=200)
+    assert agg == DamageAggregate(none=2, minor=1, severe=3, destroyed=1, unknown=1)
+    assert conn.calls[0]["radius"] == 200
+
+
+def test_nearby_damage_unknown_bucket_catches_unmapped_levels() -> None:
+    rows = [{"level": "weird", "n": 2}, {"level": "severe", "n": 1}]
+    agg = nearby_damage(_FakeConn(rows), lat=0.0, lng=0.0)
+    assert (agg.unknown, agg.severe) == (2, 1)
+
+
+def test_nearby_damage_radius_clamped_up() -> None:
+    conn = _FakeConn([])
+    nearby_damage(conn, lat=0.0, lng=0.0, radius_m=10)
+    assert conn.calls[0]["radius"] == 20
+
+
+def test_nearby_damage_radius_clamped_down() -> None:
+    conn = _FakeConn([])
+    nearby_damage(conn, lat=0.0, lng=0.0, radius_m=999_999)
+    assert conn.calls[0]["radius"] == 5000
+
+
+# ── gemini._run_tool wiring ──────────────────────────────────────────
+
+
+def test_run_tool_lookup_damage_at_address_returns_matches() -> None:
+    engine = _FakeEngine(_FakeConn([_row(score=0.95)]))
+    with patch.object(gemini_mod, "get_engine", return_value=engine):
+        payload = json.loads(gemini_mod._run_tool(
+            "lookup_damage_at_address", {"query": "Ocean Blvd"}
+        ))
+    assert payload["matches"][0]["street"] == "Ocean Blvd"
+    assert payload["matches"][0]["score"] == 0.95
+
+
+def test_run_tool_nearby_damage_returns_aggregate() -> None:
+    rows = [{"level": "severe", "n": 4}, {"level": "destroyed", "n": 2}]
+    engine = _FakeEngine(_FakeConn(rows))
+    with patch.object(gemini_mod, "get_engine", return_value=engine):
+        payload = json.loads(gemini_mod._run_tool(
+            "nearby_damage", {"lat": 33.69, "lng": -78.89, "radius_m": 300}
+        ))
+    assert payload == {"none": 0, "minor": 0, "severe": 4, "destroyed": 2, "unknown": 0}
+
+
+# ── _dominant_match helper ───────────────────────────────────────────
+
+
+def test_dominant_match_single_and_clear_winner_and_ambiguous() -> None:
+    assert gemini_mod._dominant_match([]) is None
+    single = [{"lat": 1.0, "lng": 2.0, "score": 0.4}]
+    assert gemini_mod._dominant_match(single) is single[0]
+    clear = [{"lat": 1.0, "lng": 2.0, "score": 0.9}, {"lat": 3.0, "lng": 4.0, "score": 0.5}]
+    assert gemini_mod._dominant_match(clear) is clear[0]
+    ambiguous = [{"lat": 1.0, "lng": 2.0, "score": 0.55}, {"lat": 3.0, "lng": 4.0, "score": 0.50}]
+    assert gemini_mod._dominant_match(ambiguous) is None
+
+
+# ── End-to-end: chat() emits flyTo for a dominant address match ──────
+
+
+class _FC:
+    def __init__(self, name: str, args: dict[str, Any]) -> None: self.name, self.args = name, args
+
+
+class _P:
+    def __init__(self, *, text: str | None = None, fc: _FC | None = None) -> None:
+        self.text, self.function_call = text, fc
+
+
+class _Resp:
+    def __init__(self, parts: list[_P]) -> None:
+        self.candidates = [type("C", (), {"content": type("D", (), {"parts": parts})()})()]
+
+
+class _Client:
+    def __init__(self, responses: list[_Resp]) -> None:
+        self._r, self.models = list(responses), self
+
+    def generate_content(self, **_kw: Any) -> _Resp: return self._r.pop(0)
+
+
+def _run_chat(tool_args: dict[str, Any], rows: list[dict[str, Any]]) -> tuple[str, list[dict]]:
+    call = _P(fc=_FC("lookup_damage_at_address", tool_args))
+    reply = _P(text="done.")
+    client = _Client([_Resp([call]), _Resp([reply])])
+    engine = _FakeEngine(_FakeConn(rows))
+    with patch.object(gemini_mod, "_get_client", return_value=client), \
+         patch.object(gemini_mod, "get_engine", return_value=engine):
+        r, _h, actions = gemini_mod.chat("damage?")
+    return r, actions
+
+
+def test_chat_appends_flyto_for_single_address_match() -> None:
+    _reply, actions = _run_chat(
+        {"query": "Ocean Blvd"},
+        [_row(score=0.95, lat=33.69, lng=-78.89)],
+    )
+    fly = [a for a in actions if a.get("type") == "flyTo"]
+    assert len(fly) == 1
+    assert fly[0]["zoom"] == 17
+    assert fly[0]["lat"] == pytest.approx(33.69)
+    assert fly[0]["lng"] == pytest.approx(-78.89)
+
+
+def test_chat_no_flyto_when_no_matches() -> None:
+    _reply, actions = _run_chat({"query": "Nonexistent Rd"}, [])
+    assert not any(a.get("type") == "flyTo" for a in actions)


### PR DESCRIPTION
Closes UTDisaster/frontend#51. Stacks on the pg_trgm migration PR which stacks on #66.

Teaches the Gemini chat agent to answer questions about specific addresses, streets, and neighborhoods by adding two function-calling tools against the location data.

## What is new
- **`lookup_damage_at_address(query)`**: fuzzy-matches the user-supplied address or street using `pg_trgm`'s `%` operator against `locations.street` (for short queries under 20 chars) or `locations.full_address` (for longer ones). Groups matches by `(street, city, county)`, aggregates damage counts per group, returns up to 5 ranked results. Query is trimmed to 200 characters and rejects empty or very short strings.
- **`nearby_damage(lat, lng, radius_m)`**: per-classification counts within a radius of a point, using PostGIS `ST_DWithin` on `centroid::geography`. Radius is clamped to 20 to 5000 meters.
- When `lookup_damage_at_address` returns a single match, or a clearly dominant top result (top score beats runner-up by ≥ 0.2), the chat response includes a synthetic `flyTo` action so the map auto-pans to the centroid at zoom 17.
- New `app/services/location_queries.py` holds the two SQL functions so `gemini.py` stays focused on tool wiring.
- Twelve unit tests cover short query rejection, fuzzy ordering, radius clamp both directions, the dominance threshold, and the end-to-end chat-level flyTo injection.

## What is NOT in this PR
- No frontend changes. The existing `ChatAction.flyTo` handler does the map work.
- No new npm or Python dependencies.
- No new pg extensions or migrations (those ship in the stacked PR below).

## Test plan
- [ ] `pytest tests/test_chat_address_tools.py -v` passes 12/12.
- [ ] `pytest` full suite passes 47/47.
- [ ] After both migration PRs and `util/enrich_addresses.py` run, POST to `/chat/message` with `"damage on ocean boulevard"` returns a coherent reply with counts and a `flyTo` action.
- [ ] Same query with a typo ("ocen boulevard") still matches via trgm similarity.
- [ ] Unknown street returns a graceful "no match" reply.

## Deploy gate
**Do not deploy until:**
1. PR #66 migration applied to prod Supabase.
2. PR `feat/pg-trgm-street-index` migration applied to prod Supabase.
3. `util/enrich_addresses.py` has run for the demo area on prod.

Without the `pg_trgm` indexes the `%` operator falls back to a slow sequential scan (or fails if the extension is not enabled).