### PR TITLE
feat: add address fields to locations (#64)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Backend dev commands. Run `make dev` after copying .env.example to .env.
 
-.PHONY: dev db seed test eval lint
+.PHONY: dev db seed test eval lint migrate
 
 .env:
 	cp .env.example .env
@@ -24,3 +24,6 @@ eval:
 
 lint:
 	ruff check . && black --check .
+
+migrate:
+	python util/migrate.py

--- a/app/db.py
+++ b/app/db.py
@@ -9,6 +9,7 @@ load_dotenv()
 from sqlalchemy import (
     BigInteger,
     Column,
+    DateTime,
     Float,
     ForeignKey,
     Index,
@@ -86,6 +87,12 @@ locations = Table(
     Column("classification", Text, nullable=True),
     Column("geom", Geometry("Polygon", 4326), nullable=False),
     Column("centroid", Geometry("Point", 4326), nullable=False),
+    Column("street", Text, nullable=True),
+    Column("city", Text, nullable=True),
+    Column("county", Text, nullable=True),
+    Column("full_address", Text, nullable=True),
+    Column("address_source", Text, nullable=True),
+    Column("address_fetched_at", DateTime(timezone=True), nullable=True),
 )
 
 Index("ix_locations_geom_gist", locations.c.geom, postgresql_using="gist")

--- a/app/main.py
+++ b/app/main.py
@@ -137,12 +137,25 @@ async def get_locations(
     max_lat: float = Query(...),
     disaster_id: Optional[str] = Query(None),
     limit: int = Query(5000, ge=1, le=20000),
+    include_address: bool = Query(False),
 ) -> dict[str, list[dict[str, object]]]:
     min_lng, min_lat, max_lng, max_lat = _normalize_bbox(
         min_lng, min_lat, max_lng, max_lat
     )
 
-    query = """
+    address_select = (
+        ",\n            l.street AS street,\n"
+        "            l.city AS city,\n"
+        "            l.county AS county,\n"
+        "            l.full_address AS full_address,\n"
+        "            l.address_source AS address_source,\n"
+        "            l.address_fetched_at AS address_fetched_at"
+        if include_address
+        else ""
+    )
+
+    # address_select is a hardcoded literal gated by a bool; no user input reaches the f-string.
+    query = f"""
         SELECT
             l.id AS location_id,
             l.location_uid,
@@ -167,7 +180,7 @@ async def get_locations(
             ip.post_path,
             ST_AsGeoJSON(l.geom) AS geometry,
             ST_X(l.centroid) AS centroid_lng,
-            ST_Y(l.centroid) AS centroid_lat
+            ST_Y(l.centroid) AS centroid_lat{address_select}
         FROM locations AS l
         JOIN image_pairs AS ip ON ip.id = l.image_pair_id
         LEFT JOIN chat.vlm_assessments AS a ON a.location_id = l.id
@@ -197,32 +210,45 @@ async def get_locations(
     for row in rows:
         pre_path = row["pre_path"]
         post_path = row["post_path"]
-        features.append(
-            {
-                "location_id": row["location_id"],
-                "location_uid": row["location_uid"],
-                "image_pair_id": row["image_pair_id"],
-                "disaster_id": row["disaster_id"],
-                "classification": row["classification"],
-                "damage_level": row["damage_level"],
-                "vlm_confidence": (
-                    float(row["vlm_confidence"])
-                    if row["vlm_confidence"] is not None
-                    else None
-                ),
-                "vlm_description": row["vlm_description"],
-                "feature_type": row["feature_type"],
-                "pre_path": pre_path,
-                "post_path": post_path,
-                "pre_url": _build_image_url(request, pre_path),
-                "post_url": _build_image_url(request, post_path),
-                "geometry": json.loads(row["geometry"]) if row["geometry"] else None,
-                "centroid": {
-                    "lng": row["centroid_lng"],
-                    "lat": row["centroid_lat"],
-                },
-            }
-        )
+        feature: dict[str, object] = {
+            "location_id": row["location_id"],
+            "location_uid": row["location_uid"],
+            "image_pair_id": row["image_pair_id"],
+            "disaster_id": row["disaster_id"],
+            "classification": row["classification"],
+            "damage_level": row["damage_level"],
+            "vlm_confidence": (
+                float(row["vlm_confidence"])
+                if row["vlm_confidence"] is not None
+                else None
+            ),
+            "vlm_description": row["vlm_description"],
+            "feature_type": row["feature_type"],
+            "pre_path": pre_path,
+            "post_path": post_path,
+            "pre_url": _build_image_url(request, pre_path),
+            "post_url": _build_image_url(request, post_path),
+            "geometry": json.loads(row["geometry"]) if row["geometry"] else None,
+            "centroid": {
+                "lng": row["centroid_lng"],
+                "lat": row["centroid_lat"],
+            },
+        }
+        if include_address:
+            if row["full_address"] is None and row["street"] is None and row["city"] is None and row["county"] is None:
+                feature["address"] = None
+            else:
+                fetched_at = row["address_fetched_at"]
+                # DB columns address_source / address_fetched_at map to JSON keys source / fetched_at.
+                feature["address"] = {
+                    "street": row["street"],
+                    "city": row["city"],
+                    "county": row["county"],
+                    "full_address": row["full_address"],
+                    "source": row["address_source"],
+                    "fetched_at": fetched_at.isoformat() if fetched_at is not None else None,
+                }
+        features.append(feature)
 
     return {"features": features}
 

--- a/migrations/0001_add_address_columns.sql
+++ b/migrations/0001_add_address_columns.sql
@@ -1,0 +1,8 @@
+-- 0001: add reverse-geocoded address columns to locations
+ALTER TABLE locations
+  ADD COLUMN IF NOT EXISTS street            text,
+  ADD COLUMN IF NOT EXISTS city              text,
+  ADD COLUMN IF NOT EXISTS county            text,
+  ADD COLUMN IF NOT EXISTS full_address      text,
+  ADD COLUMN IF NOT EXISTS address_source    text,
+  ADD COLUMN IF NOT EXISTS address_fetched_at timestamptz;

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -1,0 +1,21 @@
+# Migrations
+
+Plain SQL schema migrations. No Alembic.
+
+- Files are named `NNNN_description.sql` and applied in lexicographic order.
+- `util/migrate.py` walks this directory and executes each file that has not already
+  been recorded in the `schema_migrations` table (`name text primary key, applied_at timestamptz`).
+- Each file runs inside a single transaction; its filename is inserted into
+  `schema_migrations` after a successful apply.
+
+Run with:
+
+```
+make migrate
+```
+
+or directly:
+
+```
+python util/migrate.py
+```

--- a/tests/test_locations_address.py
+++ b/tests/test_locations_address.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import datetime as dt
+import os
+from contextlib import contextmanager
+from typing import Any, Iterator
+from unittest.mock import patch
+
+import pytest
+
+# conftest.py in this repo does not provide a DB fixture, so we mock the
+# engine instead of spinning up Postgres for this PR. An integration test
+# against `make db` can be layered on later without changing this contract.
+
+os.environ.setdefault("DATABASE_URL", "postgresql+psycopg://test:test@localhost:5432/test")
+os.environ.setdefault("GEMINI_API_KEY", "test-key")
+
+from fastapi.testclient import TestClient
+
+from app import main as app_main
+
+
+BASE_ROW: dict[str, Any] = {
+    "location_id": 1,
+    "location_uid": "loc-1",
+    "image_pair_id": "ip-1",
+    "feature_type": "building",
+    "classification": "no-damage",
+    "damage_level": "none",
+    "vlm_confidence": 0.9,
+    "vlm_description": "intact",
+    "disaster_id": "hurricane-florence",
+    "pre_path": "images/pre.png",
+    "post_path": "images/post.png",
+    "geometry": '{"type":"Polygon","coordinates":[[[0,0],[1,0],[1,1],[0,1],[0,0]]]}',
+    "centroid_lng": 0.5,
+    "centroid_lat": 0.5,
+}
+
+
+class _FakeResult:
+    def __init__(self, rows: list[dict[str, Any]]) -> None:
+        self._rows = rows
+
+    def mappings(self) -> "_FakeResult":
+        return self
+
+    def all(self) -> list[dict[str, Any]]:
+        return self._rows
+
+
+class _FakeConn:
+    def __init__(self, rows: list[dict[str, Any]]) -> None:
+        self._rows = rows
+
+    def execute(self, _stmt: Any, _params: dict[str, Any] | None = None) -> _FakeResult:
+        return _FakeResult(self._rows)
+
+
+class _FakeEngine:
+    def __init__(self, rows: list[dict[str, Any]]) -> None:
+        self._rows = rows
+
+    @contextmanager
+    def connect(self) -> Iterator[_FakeConn]:
+        yield _FakeConn(self._rows)
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(app_main.app)
+
+
+def _bbox_params() -> dict[str, float]:
+    return {"min_lng": -1.0, "min_lat": -1.0, "max_lng": 1.0, "max_lat": 1.0}
+
+
+def test_locations_default_response_has_no_address_key(client: TestClient) -> None:
+    rows = [dict(BASE_ROW)]
+    with patch.object(app_main, "get_engine", return_value=_FakeEngine(rows)):
+        resp = client.get("/locations", params=_bbox_params())
+    assert resp.status_code == 200
+    feature = resp.json()["features"][0]
+    assert "address" not in feature
+
+
+def test_locations_include_address_without_geocoded_fields_returns_null(client: TestClient) -> None:
+    # Design decision: when include_address=true but the row has never been
+    # geocoded, we emit `address: null` rather than an object full of nulls.
+    # Callers can distinguish "not yet fetched" from "fetched, no match" by
+    # checking `address === null` vs `address.source === 'census'`.
+    row = dict(
+        BASE_ROW,
+        street=None,
+        city=None,
+        county=None,
+        full_address=None,
+        address_source=None,
+        address_fetched_at=None,
+    )
+    with patch.object(app_main, "get_engine", return_value=_FakeEngine([row])):
+        resp = client.get("/locations", params={**_bbox_params(), "include_address": "true"})
+    assert resp.status_code == 200
+    feature = resp.json()["features"][0]
+    assert feature["address"] is None
+
+
+def test_locations_include_address_with_geocoded_fields_returns_nested_object(client: TestClient) -> None:
+    fetched = dt.datetime(2026, 4, 18, 12, 0, 0, tzinfo=dt.timezone.utc)
+    row = dict(
+        BASE_ROW,
+        street="Main St",
+        city="Wilmington",
+        county="New Hanover",
+        full_address="123 Main St, Wilmington, NC",
+        address_source="census",
+        address_fetched_at=fetched,
+    )
+    with patch.object(app_main, "get_engine", return_value=_FakeEngine([row])):
+        resp = client.get("/locations", params={**_bbox_params(), "include_address": "true"})
+    assert resp.status_code == 200
+    feature = resp.json()["features"][0]
+    assert feature["address"] == {
+        "street": "Main St",
+        "city": "Wilmington",
+        "county": "New Hanover",
+        "full_address": "123 Main St, Wilmington, NC",
+        "source": "census",
+        "fetched_at": fetched.isoformat(),
+    }

--- a/util/enrich_addresses.py
+++ b/util/enrich_addresses.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from typing import Optional
+
+import httpx
+from sqlalchemy import text
+from tqdm import tqdm
+
+from app.db import get_engine
+
+CENSUS_URL = "https://geocoding.geo.census.gov/geocoder/geographies/coordinates"
+CENSUS_BENCHMARK = "Public_AR_Current"
+CENSUS_VINTAGE = "Current_Current"
+REQUEST_TIMEOUT_SECONDS = 5.0
+RATE_LIMIT_SLEEP_SECONDS = 0.2
+DEFAULT_LIMIT = 100
+MAX_LIMIT = 1000
+
+# Nominatim fallback lives in a future PR once Census gaps are quantified.
+
+
+def geocode_coords(
+    client: httpx.Client, lat: float, lng: float
+) -> Optional[dict[str, Optional[str]]]:
+    params = {
+        "x": lng,
+        "y": lat,
+        "benchmark": CENSUS_BENCHMARK,
+        "vintage": CENSUS_VINTAGE,
+        "format": "json",
+    }
+    try:
+        resp = client.get(CENSUS_URL, params=params)
+        resp.raise_for_status()
+        payload = resp.json()
+    except (httpx.HTTPError, ValueError):
+        return None
+
+    result = payload.get("result") or {}
+    geographies = result.get("geographies") or {}
+
+    counties = geographies.get("Counties") or []
+    places = geographies.get("Incorporated Places") or geographies.get("Census Designated Places") or []
+
+    city = places[0].get("NAME") if places else None
+    county = counties[0].get("NAME") if counties else None
+    street = None
+
+    address_matches = result.get("addressMatches") or []
+    if address_matches:
+        components = address_matches[0].get("addressComponents") or {}
+        street_parts = [
+            components.get("preQualifier"),
+            components.get("preDirection"),
+            components.get("preType"),
+            components.get("streetName"),
+            components.get("suffixType"),
+            components.get("suffixDirection"),
+        ]
+        street = " ".join(p for p in street_parts if p).strip() or None
+        full_address = address_matches[0].get("matchedAddress")
+    else:
+        full_address = None
+
+    if not any([street, city, county, full_address]):
+        return None
+
+    return {
+        "street": street,
+        "city": city,
+        "county": county,
+        "full_address": full_address,
+    }
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Reverse-geocode location centroids via the U.S. Census Geocoder.")
+    parser.add_argument("--limit", type=int, default=DEFAULT_LIMIT)
+    parser.add_argument("--dry-run", action="store_true")
+    return parser.parse_args()
+
+
+SELECT_SQL = """
+SELECT id, ST_Y(centroid) AS lat, ST_X(centroid) AS lng
+FROM locations
+WHERE full_address IS NULL
+ORDER BY id
+LIMIT :limit
+"""
+
+UPDATE_SQL = """
+UPDATE locations
+SET street = :street,
+    city = :city,
+    county = :county,
+    full_address = :full_address,
+    address_source = 'census',
+    address_fetched_at = now()
+WHERE id = :id
+"""
+
+
+def main() -> int:
+    args = _parse_args()
+    limit = max(1, min(args.limit, MAX_LIMIT))
+
+    engine = get_engine()
+    with engine.connect() as conn:
+        rows = conn.execute(text(SELECT_SQL), {"limit": limit}).mappings().all()
+
+    if not rows:
+        print("no locations need geocoding")
+        return 0
+
+    updates = 0
+    with httpx.Client(timeout=REQUEST_TIMEOUT_SECONDS) as client:
+        for row in tqdm(rows, desc="geocoding"):
+            result = geocode_coords(client, float(row["lat"]), float(row["lng"]))
+            if result is None:
+                time.sleep(RATE_LIMIT_SLEEP_SECONDS)
+                continue
+
+            if args.dry_run:
+                print(f"[dry-run] id={row['id']} -> {result}")
+            else:
+                with engine.begin() as conn:
+                    conn.execute(text(UPDATE_SQL), {"id": row["id"], **result})
+                updates += 1
+
+            time.sleep(RATE_LIMIT_SLEEP_SECONDS)
+
+    if args.dry_run:
+        print(f"[dry-run] would update {sum(1 for _ in rows)} row(s)")
+    else:
+        print(f"updated {updates} row(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/util/migrate.py
+++ b/util/migrate.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
+from sqlalchemy import create_engine, text
+
+load_dotenv()
+
+MIGRATIONS_DIR = Path(__file__).resolve().parents[1] / "migrations"
+
+CREATE_TABLE_SQL = """
+CREATE TABLE IF NOT EXISTS schema_migrations (
+    name text PRIMARY KEY,
+    applied_at timestamptz NOT NULL DEFAULT now()
+)
+"""
+
+
+def _applied(conn) -> set[str]:
+    rows = conn.execute(text("SELECT name FROM schema_migrations")).all()
+    return {row[0] for row in rows}
+
+
+def _discover() -> list[Path]:
+    if not MIGRATIONS_DIR.is_dir():
+        return []
+    return sorted(p for p in MIGRATIONS_DIR.glob("*.sql") if p.is_file())
+
+
+def main() -> int:
+    db_url = os.getenv("DATABASE_URL")
+    if not db_url:
+        print("DATABASE_URL is not set", file=sys.stderr)
+        return 1
+
+    engine = create_engine(db_url, future=True)
+    with engine.begin() as conn:
+        conn.execute(text(CREATE_TABLE_SQL))
+
+    files = _discover()
+    with engine.connect() as conn:
+        already = _applied(conn)
+
+    for path in files:
+        if path.name in already:
+            continue
+        sql = path.read_text(encoding="utf-8")
+        with engine.begin() as conn:
+            conn.execute(text(sql))
+            conn.execute(
+                text("INSERT INTO schema_migrations (name) VALUES (:name)"),
+                {"name": path.name},
+            )
+        print(f"applied {path.name}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #64. Unblocks UTDisaster/frontend#51.

Stacked on #65.

Adds optional address information (street, city, county, full_address, source, timestamp) to each location so the chat and map popups can answer address-based questions without re-geocoding on every request.

## What is new
- `migrations/` folder with a plain SQL migration runner at `util/migrate.py`. Migrations are numbered SQL files applied in order and recorded in a `schema_migrations` table, so re-running is a no-op.
- `util/enrich_addresses.py` is an opt-in CLI that fills the new columns by calling the free U.S. Census Geocoder. It is rate-limited to 5 requests per second and supports `--limit` and `--dry-run`. It only updates rows where `full_address IS NULL`, so it is safe to re-run.
- `/locations` gains an opt-in `include_address=true` query parameter. **The default response shape is byte-identical to before**, so the current frontend keeps working with no changes.
- Three unit tests cover the `/locations` contract: default shape, flag on with empty fields, flag on with populated fields.

## What is NOT in this PR
- No production database is touched. The migration has to be run explicitly with `make migrate`.
- No `pg_trgm` or fuzzy-search indexes on the new columns (that belongs with the chat address lookup PR).
- No Nominatim fallback. Intentionally deferred until Census coverage gaps are quantified.

## Test plan
- [ ] `make dev`, `make seed`, `make migrate` in order. Verify the address columns exist via `psql \d locations`.
- [ ] Re-run `make migrate` and confirm it is silent (idempotent).
- [ ] `curl /locations?...` returns the original shape, no `address` key.
- [ ] `curl /locations?...&include_address=true` returns nested `address` objects (or `null` for rows without data).
- [ ] `pytest tests/test_locations_address.py -v` passes 3/3. Full suite remains green.
- [ ] `python util/enrich_addresses.py --limit 10 --dry-run` prints intended updates without writing.

---
_Recreated because the previous #66 was auto-closed when its base branch (#65) was merged and deleted. Rebased onto current main._