### PR TITLE
feat: enable pg_trgm and add trigram indexes on address columns

### DIFF
--- a/migrations/0002_pg_trgm_street_index.sql
+++ b/migrations/0002_pg_trgm_street_index.sql
@@ -1,0 +1,10 @@
+-- 0002: enable pg_trgm and index locations.street / full_address for fuzzy match
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+CREATE INDEX IF NOT EXISTS ix_locations_street_trgm
+  ON locations
+  USING gin (street gin_trgm_ops);
+
+CREATE INDEX IF NOT EXISTS ix_locations_full_address_trgm
+  ON locations
+  USING gin (full_address gin_trgm_ops);

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -7,6 +7,7 @@ Plain SQL schema migrations. No Alembic.
   been recorded in the `schema_migrations` table (`name text primary key, applied_at timestamptz`).
 - Each file runs inside a single transaction; its filename is inserted into
   `schema_migrations` after a successful apply.
+- 0002_pg_trgm_street_index.sql — enables pg_trgm and adds trigram indexes for address/street fuzzy matching
 
 Run with:
 


### PR DESCRIPTION
Stacks on #66.

Tiny migration that flips on `pg_trgm` and builds GIN trigram indexes on `locations.street` and `locations.full_address`. This is what makes fuzzy address search (like typing "ocen blvd" and matching "Ocean Blvd") fast once the address data is populated.

## Why this is its own PR
Split out deliberately so the extension and indexes can be applied to production Supabase as a standalone deploy step **before** the chat tools that use them (PR for `feat/chat-address-tools`) ship. Keeps the deploy-gate conversation clean.

## What is new
- `migrations/0002_pg_trgm_street_index.sql` — `CREATE EXTENSION IF NOT EXISTS pg_trgm` + two `CREATE INDEX IF NOT EXISTS ... USING gin (<col> gin_trgm_ops)`.

## What is NOT in this PR
- No Python changes.
- No new schema columns.
- No queries that use these indexes yet. Application code stays working with or without them.

## Test plan
- [ ] After #66 merges and is applied to a local database, run `make migrate` and see `applied 0002_pg_trgm_street_index.sql`.
- [ ] Re-run `make migrate`, silent (no-op via `schema_migrations`).
- [ ] `\di+ locations_*_trgm` shows both new GIN indexes.
- [ ] Sample `SELECT ... WHERE street % 'Ocean'` `EXPLAIN` shows an index scan, not a seq scan.
- [ ] Run on prod Supabase ONLY after explicit approval.

## Deploy gate
Requires PR #66 migrations applied to prod before this one can deploy. Does not require any application code change.

---
_Recreated because the previous #69 was auto-closed when its base branch (feat/locations-addresses) was merged and deleted. Rebased onto current main._