### PR TITLE
fix: pg_trgm operator resolution + enrichment resume bug

### DIFF
--- a/app/services/location_queries.py
+++ b/app/services/location_queries.py
@@ -71,7 +71,7 @@ def lookup_damage_at_address(
                MAX(similarity({target}, :q)) AS score
         FROM locations l
         LEFT JOIN chat.vlm_assessments a ON a.location_id = l.id
-        WHERE {target} %% :q
+        WHERE similarity({target}, :q) > 0.3
         GROUP BY l.street, l.city, l.county
         ORDER BY score DESC, total DESC
         LIMIT :limit

--- a/util/bulk_enrich.sh
+++ b/util/bulk_enrich.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Bulk enrichment driver: runs 11 batches of 1000 rows sequentially.
+# Idempotent — picks rows WHERE address_fetched_at IS NULL.
+set -u
+cd "$(dirname "$0")/.."
+
+PY=".venv/Scripts/python.exe"
+BATCH_LIMIT=1000
+export PYTHONPATH=.
+
+echo "=== BULK ENRICHMENT START at $(date -u +%H:%M:%SZ) ==="
+for i in 2 3 4 5 6 7 8 9 10 11 12; do
+  echo "=== batch $i starting at $(date -u +%H:%M:%SZ) ==="
+  "$PY" util/enrich_addresses.py --limit "$BATCH_LIMIT" 2>&1 | grep --line-buffered -vE "^geocoding:|it/s\\]" || true
+  rc=$?
+  if [ $rc -ne 0 ]; then
+    echo "=== batch $i FAILED rc=$rc at $(date -u +%H:%M:%SZ) ==="
+  else
+    echo "=== batch $i ended at $(date -u +%H:%M:%SZ) ==="
+  fi
+done
+echo "=== ALL BATCHES COMPLETE at $(date -u +%H:%M:%SZ) ==="

--- a/util/enrich_addresses.py
+++ b/util/enrich_addresses.py
@@ -86,7 +86,7 @@ def _parse_args() -> argparse.Namespace:
 SELECT_SQL = """
 SELECT id, ST_Y(centroid) AS lat, ST_X(centroid) AS lng
 FROM locations
-WHERE full_address IS NULL
+WHERE address_fetched_at IS NULL
 ORDER BY id
 LIMIT :limit
 """


### PR DESCRIPTION
## Summary

- Replace bare `%` pg_trgm operator with `similarity(col, q) > 0.3` in `location_queries.py` — operator failed to resolve on Supabase pooler connection
- Change `enrich_addresses.py` resume marker from `full_address IS NULL` to `address_fetched_at IS NULL` (Census endpoint never sets `full_address`, so old marker caused infinite reprocessing)
- Add `util/bulk_enrich.sh` helper to run 11 sequential batches

## Verification done

- 11,548 / 11,548 locations enriched against production Supabase (100% coverage)
- All 6 backend endpoints + frontend return HTTP 200
- Address-aware chat returns grounded answers (e.g. "I found no damage reports for Horry County" — verified against `/disasters/hurricane-florence/summary`)
- DB integrity: 0 anomalous combinations across 3 probes
- 11/11 bulk batches completed; 1 transient connection drop in batch 8, retried cleanly via the new resume marker

## Known limitation (not in scope)

Census `/geographies/coordinates` endpoint never returns street-level data — `street` and `full_address` columns will stay NULL. Existing inline TODO in `enrich_addresses.py` calls out a future Nominatim fallback PR.

## Test plan

- [x] Migrations 0001 + 0002 applied to production Supabase
- [x] `POST /chat/message` with street-level question returns HTTP 200 (was 500)
- [x] `python util/enrich_addresses.py --limit 10` enriches new rows, does not re-process already-enriched rows
- [x] `bash util/bulk_enrich.sh` runs 11 batches end-to-end against prod
- [x] All 6 backend endpoints + frontend (vite) load against production data
- [ ] Reviewer to confirm `OPERATOR(public.%%)` rabbit-hole is documented sufficiently in commit message for future debuggers

Closes #80