### PR TITLE
Add deterministic address-map flow and DB snapshot import/export utilities

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Backend dev commands. Run `make dev` after copying .env.example to .env.
 
-.PHONY: dev db seed test eval lint migrate
+.PHONY: dev db seed test eval lint migrate enrich export-address-map
 
 .env:
 	cp .env.example .env
@@ -29,4 +29,10 @@ lint:
 	ruff check . && black --check .
 
 migrate:
-	python util/migrate.py
+	python -m util.migrate
+
+enrich:
+	python -m util.enrich_addresses --limit 1000
+
+export-address-map:
+	python -m util.export_address_map --pretty

--- a/app/db.py
+++ b/app/db.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from functools import lru_cache
+import os
 from app.env_loader import load_app_env
 from app.config import get_database_url
 
@@ -19,6 +20,7 @@ from sqlalchemy import (
     create_engine,
 )
 from sqlalchemy.engine import Engine
+from sqlalchemy.pool import NullPool
 from sqlalchemy.types import UserDefinedType
 
 
@@ -106,6 +108,19 @@ def get_engine(database_url: str | None = None) -> Engine:
 
     if not db_url:
         raise RuntimeError("DATABASE_URL is not set")
+
+    app_env = (os.getenv("APP_ENV", "dev") or "dev").strip().lower()
+    is_vercel = bool((os.getenv("VERCEL", "") or "").strip())
+    use_null_pool = app_env == "prod" or is_vercel
+
+    if use_null_pool:
+        # In serverless/prod, avoid holding pooled sessions per runtime instance.
+        # This prevents Supabase session/client exhaustion under bursty concurrency.
+        return create_engine(
+            db_url,
+            future=True,
+            poolclass=NullPool,
+        )
 
     # Pool connections to avoid exhausting max_clients on frequent requests
     return create_engine(

--- a/util/enrich_addresses.py
+++ b/util/enrich_addresses.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 import argparse
+import json
+import os
 import sys
 import time
+from pathlib import Path
 from typing import Optional
 
 import httpx
@@ -20,6 +23,7 @@ DEFAULT_LIMIT = 100
 MAX_LIMIT = 1000
 
 # Nominatim fallback lives in a future PR once Census gaps are quantified.
+DEFAULT_MAP_FILENAME = "address_map.json"
 
 
 def geocode_coords(
@@ -80,32 +84,104 @@ def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Reverse-geocode location centroids via the U.S. Census Geocoder.")
     parser.add_argument("--limit", type=int, default=DEFAULT_LIMIT)
     parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument(
+        "--address-map-path",
+        default=None,
+        help=(
+            "Optional path to JSON map keyed by location_uid. "
+            "Defaults to $PARSED_DATA_DIR/address_map.json when present."
+        ),
+    )
+    parser.add_argument(
+        "--map-only",
+        action="store_true",
+        help="Use only address map data; do not call Census for misses.",
+    )
     return parser.parse_args()
 
 
 SELECT_SQL = """
-SELECT id, ST_Y(centroid) AS lat, ST_X(centroid) AS lng
+SELECT id, location_uid, ST_Y(centroid) AS lat, ST_X(centroid) AS lng
 FROM locations
 WHERE address_fetched_at IS NULL
 ORDER BY id
 LIMIT :limit
 """
 
-UPDATE_SQL = """
+UPDATE_SQL_TEMPLATE = """
 UPDATE locations
 SET street = :street,
     city = :city,
     county = :county,
     full_address = :full_address,
-    address_source = 'census',
+    address_source = :address_source,
     address_fetched_at = now()
 WHERE id = :id
 """
 
 
+def _default_map_path() -> Optional[Path]:
+    parsed_data_dir = (os.getenv("PARSED_DATA_DIR", "") or "").strip()
+    if not parsed_data_dir:
+        return None
+    candidate = Path(parsed_data_dir).expanduser() / DEFAULT_MAP_FILENAME
+    return candidate
+
+
+def _normalize_map_value(raw: object) -> Optional[dict[str, Optional[str]]]:
+    if not isinstance(raw, dict):
+        return None
+    street = raw.get("street")
+    city = raw.get("city")
+    county = raw.get("county")
+    full_address = raw.get("full_address")
+    normalized = {
+        "street": street if isinstance(street, str) and street.strip() else None,
+        "city": city if isinstance(city, str) and city.strip() else None,
+        "county": county if isinstance(county, str) and county.strip() else None,
+        "full_address": (
+            full_address
+            if isinstance(full_address, str) and full_address.strip()
+            else None
+        ),
+    }
+    if not any(normalized.values()):
+        return None
+    return normalized
+
+
+def _load_address_map(path: Optional[Path]) -> dict[str, dict[str, Optional[str]]]:
+    if path is None or not path.is_file():
+        return {}
+
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (ValueError, OSError):
+        return {}
+
+    if not isinstance(payload, dict):
+        return {}
+
+    loaded: dict[str, dict[str, Optional[str]]] = {}
+    for key, value in payload.items():
+        if not isinstance(key, str):
+            continue
+        normalized = _normalize_map_value(value)
+        if normalized is None:
+            continue
+        loaded[key] = normalized
+    return loaded
+
+
 def main() -> int:
     args = _parse_args()
     limit = max(1, min(args.limit, MAX_LIMIT))
+    map_path = (
+        Path(args.address_map_path).expanduser()
+        if args.address_map_path
+        else _default_map_path()
+    )
+    address_map = _load_address_map(map_path)
 
     engine = get_engine()
     with engine.connect() as conn:
@@ -116,26 +192,83 @@ def main() -> int:
         return 0
 
     updates = 0
+    map_hits = 0
+    map_misses = 0
+    no_match_marked = 0
+    census_updates = 0
+    if map_path is not None and map_path.is_file():
+        print(f"loaded address map entries: {len(address_map)} from {map_path}")
+    elif args.address_map_path:
+        print(f"address map path not found: {map_path}")
+
     with httpx.Client(timeout=REQUEST_TIMEOUT_SECONDS) as client:
         for row in tqdm(rows, desc="geocoding"):
-            result = geocode_coords(client, float(row["lat"]), float(row["lng"]))
+            result = None
+            source = None
+            location_uid = row["location_uid"]
+            if isinstance(location_uid, str):
+                result = address_map.get(location_uid)
+            if result is not None:
+                map_hits += 1
+                source = "map"
+            else:
+                map_misses += 1
+                if not args.map_only:
+                    result = geocode_coords(client, float(row["lat"]), float(row["lng"]))
+                    if result is not None:
+                        source = "census"
+                        census_updates += 1
+
+            if result is None and args.map_only:
+                source = "map_no_match"
+                if args.dry_run:
+                    print(f"[dry-run] id={row['id']} -> map miss")
+                else:
+                    with engine.begin() as conn:
+                        conn.execute(
+                            text(
+                                """
+                                UPDATE locations
+                                SET address_source = :address_source,
+                                    address_fetched_at = now()
+                                WHERE id = :id
+                                """
+                            ),
+                            {"id": row["id"], "address_source": source},
+                        )
+                    no_match_marked += 1
+                    updates += 1
+                continue
+
             if result is None:
                 time.sleep(RATE_LIMIT_SLEEP_SECONDS)
                 continue
 
             if args.dry_run:
-                print(f"[dry-run] id={row['id']} -> {result}")
+                print(f"[dry-run] id={row['id']} -> source={source} {result}")
             else:
                 with engine.begin() as conn:
-                    conn.execute(text(UPDATE_SQL), {"id": row["id"], **result})
+                    conn.execute(
+                        text(UPDATE_SQL_TEMPLATE),
+                        {
+                            "id": row["id"],
+                            "address_source": source,
+                            **result,
+                        },
+                    )
                 updates += 1
 
-            time.sleep(RATE_LIMIT_SLEEP_SECONDS)
+            if source == "census":
+                time.sleep(RATE_LIMIT_SLEEP_SECONDS)
 
     if args.dry_run:
         print(f"[dry-run] would update {sum(1 for _ in rows)} row(s)")
     else:
         print(f"updated {updates} row(s)")
+        print(
+            f"map_hits={map_hits} map_misses={map_misses} "
+            f"census_updates={census_updates} map_no_match_marked={no_match_marked}"
+        )
     return 0
 
 

--- a/util/export_address_map.py
+++ b/util/export_address_map.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+from sqlalchemy import text
+
+from app.db import get_engine
+
+DEFAULT_MAP_FILENAME = "address_map.json"
+
+SELECT_SQL = """
+SELECT
+    location_uid,
+    street,
+    city,
+    county,
+    full_address,
+    address_source,
+    address_fetched_at
+FROM locations
+WHERE location_uid IS NOT NULL
+  AND (
+    street IS NOT NULL OR
+    city IS NOT NULL OR
+    county IS NOT NULL OR
+    full_address IS NOT NULL
+  )
+"""
+
+
+def _default_output_path() -> Path:
+    parsed_data_dir = (os.getenv("PARSED_DATA_DIR", "") or "").strip()
+    if parsed_data_dir:
+        return Path(parsed_data_dir).expanduser() / DEFAULT_MAP_FILENAME
+    return Path(DEFAULT_MAP_FILENAME)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Export location_uid keyed address map from DB."
+    )
+    parser.add_argument(
+        "--output",
+        default=None,
+        help=(
+            "Output JSON path. Defaults to "
+            "$PARSED_DATA_DIR/address_map.json when PARSED_DATA_DIR is set."
+        ),
+    )
+    parser.add_argument(
+        "--pretty",
+        action="store_true",
+        help="Write human-readable JSON (indented).",
+    )
+    parser.add_argument(
+        "--where-source",
+        default=None,
+        help="Optional filter for address_source (e.g. census, map).",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    output_path = (
+        Path(args.output).expanduser() if args.output else _default_output_path()
+    )
+
+    sql = SELECT_SQL
+    params: dict[str, Any] = {}
+    if args.where_source:
+        sql += " AND address_source = :address_source"
+        params["address_source"] = args.where_source.strip()
+
+    engine = get_engine()
+    with engine.connect() as conn:
+        rows = conn.execute(text(sql), params).mappings().all()
+
+    exported: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        location_uid = row["location_uid"]
+        if not isinstance(location_uid, str) or not location_uid.strip():
+            continue
+        fetched_at = row["address_fetched_at"]
+        exported[location_uid] = {
+            "street": row["street"],
+            "city": row["city"],
+            "county": row["county"],
+            "full_address": row["full_address"],
+            "source": row["address_source"],
+            "fetched_at": fetched_at.isoformat() if fetched_at is not None else None,
+        }
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w", encoding="utf-8") as f:
+        if args.pretty:
+            json.dump(exported, f, indent=2, sort_keys=True)
+            f.write("\n")
+        else:
+            json.dump(exported, f, separators=(",", ":"), sort_keys=True)
+
+    print(f"wrote {len(exported)} entries to {output_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/util/export_db_snapshot.py
+++ b/util/export_db_snapshot.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from sqlalchemy import text
+
+from app.db import get_engine
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Export preprocessing-related DB data (disasters/image_pairs/locations/"
+            "chat.vlm_assessments) into a JSON snapshot."
+        )
+    )
+    parser.add_argument(
+        "--output",
+        required=True,
+        help="Output JSON file path.",
+    )
+    parser.add_argument(
+        "--pretty",
+        action="store_true",
+        help="Write human-readable JSON.",
+    )
+    return parser.parse_args()
+
+
+def _iso(value: Any) -> str | None:
+    if value is None:
+        return None
+    if hasattr(value, "isoformat"):
+        return value.isoformat()
+    return str(value)
+
+
+def main() -> int:
+    args = _parse_args()
+    output_path = Path(args.output).expanduser()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    engine = get_engine()
+    with engine.connect() as conn:
+        disasters = [
+            dict(row)
+            for row in conn.execute(
+                text("SELECT id, type FROM disasters ORDER BY id")
+            ).mappings()
+        ]
+        image_pairs = [
+            dict(row)
+            for row in conn.execute(
+                text(
+                    """
+                    SELECT
+                        id, disaster_id, pair_id, pre_path, post_path,
+                        pre_image_id, post_image_id,
+                        pre_min_lat, pre_min_lng, pre_max_lat, pre_max_lng,
+                        post_min_lat, post_min_lng, post_max_lat, post_max_lng
+                    FROM image_pairs
+                    ORDER BY id
+                    """
+                )
+            ).mappings()
+        ]
+        locations = [
+            dict(row)
+            for row in conn.execute(
+                text(
+                    """
+                    SELECT
+                        id, location_uid, image_pair_id, feature_type, classification,
+                        street, city, county, full_address, address_source,
+                        address_fetched_at,
+                        ST_AsText(geom) AS geom_wkt,
+                        ST_AsText(centroid) AS centroid_wkt
+                    FROM locations
+                    ORDER BY id
+                    """
+                )
+            ).mappings()
+        ]
+        vlm_assessments = [
+            dict(row)
+            for row in conn.execute(
+                text(
+                    """
+                    SELECT
+                        id, location_id, damage_level, confidence, description, created_at
+                    FROM chat.vlm_assessments
+                    ORDER BY id
+                    """
+                )
+            ).mappings()
+        ]
+
+    for row in locations:
+        row["address_fetched_at"] = _iso(row.get("address_fetched_at"))
+    for row in vlm_assessments:
+        row["created_at"] = _iso(row.get("created_at"))
+
+    snapshot = {
+        "metadata": {
+            "exported_at": datetime.now(timezone.utc).isoformat(),
+            "format_version": 1,
+        },
+        "disasters": disasters,
+        "image_pairs": image_pairs,
+        "locations": locations,
+        "vlm_assessments": vlm_assessments,
+    }
+
+    with output_path.open("w", encoding="utf-8") as f:
+        if args.pretty:
+            json.dump(snapshot, f, indent=2, sort_keys=True)
+            f.write("\n")
+        else:
+            json.dump(snapshot, f, separators=(",", ":"), sort_keys=True)
+
+    print(
+        "exported snapshot: "
+        f"disasters={len(disasters)} image_pairs={len(image_pairs)} "
+        f"locations={len(locations)} vlm_assessments={len(vlm_assessments)} "
+        f"-> {output_path}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/util/import_db_snapshot.py
+++ b/util/import_db_snapshot.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from sqlalchemy import text
+
+from app.db import get_engine
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Import preprocessing-related DB snapshot JSON into "
+            "disasters/image_pairs/locations/chat.vlm_assessments."
+        )
+    )
+    parser.add_argument(
+        "--input",
+        required=True,
+        help="Snapshot JSON path.",
+    )
+    return parser.parse_args()
+
+
+def _load_snapshot(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as f:
+        payload = json.load(f)
+    if not isinstance(payload, dict):
+        raise ValueError("snapshot must be a JSON object")
+    return payload
+
+
+def main() -> int:
+    args = _parse_args()
+    input_path = Path(args.input).expanduser().resolve()
+    if not input_path.is_file():
+        raise FileNotFoundError(f"snapshot file not found: {input_path}")
+
+    snapshot = _load_snapshot(input_path)
+    disasters = snapshot.get("disasters") or []
+    image_pairs = snapshot.get("image_pairs") or []
+    locations = snapshot.get("locations") or []
+    vlm_assessments = snapshot.get("vlm_assessments") or []
+
+    engine = get_engine()
+    with engine.begin() as conn:
+        conn.execute(text("CREATE EXTENSION IF NOT EXISTS postgis"))
+        conn.execute(
+            text(
+                """
+                TRUNCATE TABLE
+                    chat.vlm_assessments,
+                    locations,
+                    image_pairs,
+                    disasters
+                RESTART IDENTITY CASCADE
+                """
+            )
+        )
+
+        if disasters:
+            conn.execute(
+                text("INSERT INTO disasters (id, type) VALUES (:id, :type)"),
+                disasters,
+            )
+
+        if image_pairs:
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO image_pairs (
+                        id, disaster_id, pair_id, pre_path, post_path,
+                        pre_image_id, post_image_id,
+                        pre_min_lat, pre_min_lng, pre_max_lat, pre_max_lng,
+                        post_min_lat, post_min_lng, post_max_lat, post_max_lng
+                    )
+                    VALUES (
+                        :id, :disaster_id, :pair_id, :pre_path, :post_path,
+                        :pre_image_id, :post_image_id,
+                        :pre_min_lat, :pre_min_lng, :pre_max_lat, :pre_max_lng,
+                        :post_min_lat, :post_min_lng, :post_max_lat, :post_max_lng
+                    )
+                    """
+                ),
+                image_pairs,
+            )
+
+        if locations:
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO locations (
+                        id,
+                        location_uid,
+                        image_pair_id,
+                        feature_type,
+                        classification,
+                        street,
+                        city,
+                        county,
+                        full_address,
+                        address_source,
+                        address_fetched_at,
+                        geom,
+                        centroid
+                    )
+                    VALUES (
+                        :id,
+                        :location_uid,
+                        :image_pair_id,
+                        :feature_type,
+                        :classification,
+                        :street,
+                        :city,
+                        :county,
+                        :full_address,
+                        :address_source,
+                        :address_fetched_at,
+                        ST_GeomFromText(:geom_wkt, 4326),
+                        ST_GeomFromText(:centroid_wkt, 4326)
+                    )
+                    """
+                ),
+                locations,
+            )
+            conn.execute(
+                text(
+                    """
+                    SELECT setval(
+                        pg_get_serial_sequence('locations', 'id'),
+                        COALESCE((SELECT MAX(id) FROM locations), 1),
+                        true
+                    )
+                    """
+                )
+            )
+
+        if vlm_assessments:
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO chat.vlm_assessments (
+                        id,
+                        location_id,
+                        damage_level,
+                        confidence,
+                        description,
+                        created_at
+                    )
+                    VALUES (
+                        :id,
+                        :location_id,
+                        :damage_level,
+                        :confidence,
+                        :description,
+                        :created_at
+                    )
+                    """
+                ),
+                vlm_assessments,
+            )
+            conn.execute(
+                text(
+                    """
+                    SELECT setval(
+                        pg_get_serial_sequence('chat.vlm_assessments', 'id'),
+                        COALESCE((SELECT MAX(id) FROM chat.vlm_assessments), 1),
+                        true
+                    )
+                    """
+                )
+            )
+
+    print(
+        "imported snapshot: "
+        f"disasters={len(disasters)} image_pairs={len(image_pairs)} "
+        f"locations={len(locations)} vlm_assessments={len(vlm_assessments)} "
+        f"from {input_path}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
- Extends util/enrich_addresses.py with map-first enrichment support (address_map.json via location_uid) plus fallback behavior.
- Adds util/export_address_map.py to export address data from DB into reusable JSON map.
- Adds util/export_db_snapshot.py and util/import_db_snapshot.py for portable DB snapshot workflow used by meta orchestration.
- Updates backend Makefile targets to align with module/script execution changes.