### PR TITLE
fix: Gemini client cache invalidation + error detail propagation (#78)

### DIFF
--- a/app/routers/chat.py
+++ b/app/routers/chat.py
@@ -132,13 +132,14 @@ def send_message(req: ChatRequest) -> dict:
                 disaster_name=req.disaster_name,
             )
         except ChatBackendUnavailableError as exc:
-            logger.warning("Chat unavailable: status=%s", exc.status_code)
+            logger.warning("Chat unavailable: status=%s detail=%s", exc.status_code, exc.detail)
             headers = {}
             if exc.retry_after_seconds:
                 headers["Retry-After"] = str(exc.retry_after_seconds)
+            detail = exc.detail if exc.detail else "Chat is temporarily unavailable. Please try again later."
             raise HTTPException(
                 status_code=503,
-                detail="Chat is temporarily unavailable. Please try again later.",
+                detail=detail,
                 headers=headers or None,
             ) from exc
 

--- a/app/services/gemini.py
+++ b/app/services/gemini.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import os
 import json
+import logging
 import re
-from functools import lru_cache
+import threading
+
 from google import genai
 from google.genai import types
 from google.genai.errors import ClientError
@@ -17,15 +19,20 @@ from app.services.location_queries import (
 )
 
 load_app_env()
+logger = logging.getLogger(__name__)
 
 
 class ChatBackendUnavailableError(Exception):
     def __init__(
-        self, status_code: int = 503, retry_after_seconds: int | None = None
+        self,
+        status_code: int = 503,
+        retry_after_seconds: int | None = None,
+        detail: str = "Chat backend unavailable",
     ) -> None:
-        super().__init__("Chat backend unavailable")
+        super().__init__(detail)
         self.status_code = status_code
         self.retry_after_seconds = retry_after_seconds
+        self.detail = detail
 
 
 def _extract_retry_after_seconds(message: str) -> int | None:
@@ -38,12 +45,36 @@ def _extract_retry_after_seconds(message: str) -> int | None:
     return None
 
 
-@lru_cache(maxsize=1)
+_client_lock = threading.Lock()
+_cached_client: genai.Client | None = None
+
+
 def _get_client() -> genai.Client:
-    api_key = os.getenv("GEMINI_API_KEY")
-    if not api_key:
-        raise ChatBackendUnavailableError(status_code=503)
-    return genai.Client(api_key=api_key)
+    global _cached_client
+    with _client_lock:
+        if _cached_client is not None:
+            return _cached_client
+        api_key = os.getenv("GEMINI_API_KEY")
+        if not api_key:
+            raise ChatBackendUnavailableError(
+                status_code=503,
+                detail="Gemini API key is not configured.",
+            )
+        _cached_client = genai.Client(api_key=api_key)
+        return _cached_client
+
+
+def _invalidate_client() -> None:
+    global _cached_client
+    with _client_lock:
+        _cached_client = None
+
+
+def _is_auth_error(exc: ClientError) -> bool:
+    status = getattr(exc, "status_code", None)
+    return status in (401, 403)
+
+
 # ── Tool definitions (Gemini decides when to call these) ─────────────
 
 TOOLS = [
@@ -933,6 +964,13 @@ def chat(
         except ClientError as exc:
             message = str(exc)
             status_code = getattr(exc, "status_code", 503)
+            if _is_auth_error(exc):
+                _invalidate_client()
+                logger.error("Gemini API key rejected (HTTP %s)", status_code)
+                raise ChatBackendUnavailableError(
+                    status_code=503,
+                    detail="The Gemini API key is invalid or expired. Please check your configuration.",
+                ) from exc
             if status_code == 429 or "RESOURCE_EXHAUSTED" in message:
                 raise ChatBackendUnavailableError(
                     status_code=503,


### PR DESCRIPTION
## Summary

- Replace lru_cache with thread-safe invalidatable Gemini client cache
- On 401/403, clear cached client so next request picks up a fresh API key without restart
- Surface descriptive error messages to frontend instead of generic "temporarily unavailable"

Closes #78

## Changes (2 files, +49/-10)

### app/services/gemini.py
- Thread-safe _get_client() with _client_lock and _invalidate_client()
- _is_auth_error() detects 401/403 from Gemini
- ChatBackendUnavailableError gains detail field for descriptive messages
- Auth errors trigger client invalidation + clear log message

### app/routers/chat.py
- Pass exc.detail to HTTPException response (always 503 status)
- Log detail alongside status code

## Test plan
- [ ] Start backend with valid Gemini key — verify chat responds
- [ ] Set invalid key in .env, restart — verify "API key is invalid" error message
- [ ] Rotate key back to valid — verify chat recovers on next request
- [ ] Send rapid messages — verify rate limiting shows retry-after
