### PR TITLE
fix: map l.classification fallback to FEMA labels

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -252,7 +252,14 @@ _NORMALIZED_DAMAGE_SQL = """
                 WHEN 'unknown' THEN 'Unknown'
                 ELSE a.damage_level
             END,
-            l.classification
+            CASE l.classification
+                WHEN 'none' THEN 'No Damage'
+                WHEN 'minor' THEN 'Minor Damage'
+                WHEN 'severe' THEN 'Major Damage'
+                WHEN 'destroyed' THEN 'Destroyed'
+                WHEN 'unknown' THEN 'Unknown'
+                ELSE l.classification
+            END
         )
 """
 

--- a/app/services/gemini.py
+++ b/app/services/gemini.py
@@ -378,7 +378,14 @@ _EFFECTIVE_DAMAGE_SQL = """COALESCE(
         WHEN 'unknown' THEN 'Unknown'
         ELSE a.damage_level
     END,
-    l.classification,
+    CASE l.classification
+        WHEN 'none' THEN 'No Damage'
+        WHEN 'minor' THEN 'Minor Damage'
+        WHEN 'severe' THEN 'Major Damage'
+        WHEN 'destroyed' THEN 'Destroyed'
+        WHEN 'unknown' THEN 'Unknown'
+        ELSE l.classification
+    END,
     'Unknown'
 )"""
 


### PR DESCRIPTION
Locations without VLM assessments fall through COALESCE to l.classification which stores old-style labels (none, minor, severe). Added a CASE mapping for l.classification in both _NORMALIZED_DAMAGE_SQL and _EFFECTIVE_DAMAGE_SQL so all API responses use consistent FEMA labels.