### PR TITLE
fix: harden edge cases from quality review

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -250,7 +250,7 @@ _NORMALIZED_DAMAGE_SQL = """
                 WHEN 'major-damage' THEN 'Major Damage'
                 WHEN 'destroyed' THEN 'Destroyed'
                 WHEN 'unknown' THEN 'Unknown'
-                ELSE a.damage_level
+                ELSE NULL
             END,
             CASE l.classification
                 WHEN 'none' THEN 'No Damage'
@@ -258,8 +258,9 @@ _NORMALIZED_DAMAGE_SQL = """
                 WHEN 'severe' THEN 'Major Damage'
                 WHEN 'destroyed' THEN 'Destroyed'
                 WHEN 'unknown' THEN 'Unknown'
-                ELSE l.classification
-            END
+                ELSE NULL
+            END,
+            'Unknown'
         )
 """
 

--- a/app/routers/chat.py
+++ b/app/routers/chat.py
@@ -4,7 +4,7 @@ import json
 import logging
 from typing import Optional
 from fastapi import APIRouter, HTTPException, Query
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from sqlalchemy import text
 
 from app.db import get_engine
@@ -27,7 +27,7 @@ class ViewportBounds(BaseModel):
 
 
 class ChatRequest(BaseModel):
-    message:        str
+    message:        str = Field(..., min_length=1)
     conversation_id: Optional[int] = None   # None = start new conversation
     viewport:       Optional[ViewportBounds] = None
     disaster_id:    Optional[str] = None
@@ -209,8 +209,10 @@ def delete_conversation(conversation_id: int) -> dict:
     """Delete a conversation and all its messages."""
     engine = get_engine()
     with engine.begin() as conn:
-        conn.execute(
+        result = conn.execute(
             text("DELETE FROM chat.conversations WHERE id = :cid"),
             {"cid": conversation_id}
         )
+        if result.rowcount == 0:
+            raise HTTPException(status_code=404, detail="Conversation not found")
     return {"status": "deleted", "conversation_id": conversation_id}

--- a/app/services/gemini.py
+++ b/app/services/gemini.py
@@ -751,6 +751,10 @@ def _run_tool(
             return json.dumps(dict(row))
 
         elif tool_name == "compare_disasters":
+            raw_ids = args.get("disaster_ids", [])
+            ids = [str(x) for x in raw_ids if isinstance(x, str) and x.strip()][:10]
+            if not ids:
+                return json.dumps({"error": "No valid disaster IDs provided"})
             rows = conn.execute(
                 text(f"""
                     SELECT
@@ -764,7 +768,7 @@ def _run_tool(
                     GROUP BY 1, 2
                     ORDER BY 1, count DESC
                 """),
-                {"ids": args["disaster_ids"]}
+                {"ids": ids}
             ).mappings().all()
             return json.dumps([dict(r) for r in rows])
 
@@ -801,13 +805,14 @@ def _run_tool(
 
         elif tool_name == "get_damage_by_area":
             area_type = str(args.get("area_type") or "city")
-            area_name = str(args.get("area_name") or "")
-            if not area_name.strip():
+            area_name = str(args.get("area_name") or "")[:100].strip()
+            if not area_name:
                 return json.dumps({"error": "area_name is required"})
             column_map = {"city": "l.city", "county": "l.county", "street": "l.street"}
             column = column_map.get(area_type)
             if column is None:
                 return json.dumps({"error": f"Invalid area_type: must be one of city, county, street"})
+            escaped = area_name.replace("%", r"\%").replace("_", r"\_")
             query = f"""
                 SELECT
                     {_EFFECTIVE_DAMAGE_SQL} AS damage_level,
@@ -815,9 +820,9 @@ def _run_tool(
                 FROM locations l
                 JOIN image_pairs ip ON ip.id = l.image_pair_id
                 LEFT JOIN chat.vlm_assessments a ON a.location_id = l.id
-                WHERE {column} ILIKE :area_pattern
+                WHERE {column} ILIKE :area_pattern ESCAPE '\\'
             """
-            params: dict = {"area_pattern": f"%{area_name}%"}
+            params: dict = {"area_pattern": f"%{escaped}%"}
             if args.get("disaster_id"):
                 query += " AND ip.disaster_id = :disaster_id"
                 params["disaster_id"] = args["disaster_id"]


### PR DESCRIPTION
## Summary

- **NORMALIZED_DAMAGE_SQL**: `ELSE NULL` with `'Unknown'` COALESCE fallback prevents raw DB values (`none`, `minor`, `severe`) from leaking into API responses
- **delete_conversation**: Returns 404 when conversation doesn't exist instead of silent success
- **ChatRequest.message**: Rejects empty strings via Pydantic `Field(min_length=1)`
- **compare_disasters**: Validates and clamps `disaster_ids` list to max 10 entries
- **get_damage_by_area**: Length-limits `area_name` to 100 chars and escapes ILIKE wildcards (`%`, `_`)

Fixes found by automated quality review agents after Groups 3+4 merge.

## Test plan
- [x] E2E: /locations returns only FEMA labels (No Damage, Minor Damage, Major Damage, Destroyed, Unknown)
- [x] E2E: /disasters/hurricane-florence/summary keys match FEMA labels
- [x] DELETE /chat/conversations/999999 returns 404
- [x] POST /chat/message with empty string rejected (422)
- [x] Chat tool: compare_disasters with empty list returns error JSON
- [x] Chat tool: get_damage_by_area with wildcard chars doesn't break query